### PR TITLE
Added missing features for Issue #241:

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2121,3 +2121,12 @@ Must have event, even if it's empty, since it's applied by the source to generat
 25-01-2020, Nolok
 - Fixed: Invalid keywords in the [ADVANCE] block were likely to cause memory corruption.
 - Updated: SQlite to version 3.31.0.
+
+05-02-2020, Drk84
+- Added: New ini flag NPCCanFizzle, when enabled, a NPC can fizzle a spell when hit during combat. (Issue #241)
+- Added: TAG.NPCNoCastTill behaviour, this tag will not allow a NPC to cast a spell if tag.NPCNoCastTill > SERV.Time.
+		 Example:
+		  ON=@SpellCast
+		  tag.NPCNoCastTill = <eval <serv.time> + <argn3> + 50>
+		 In this case, the next spell will be casted after 5 seconds, ARGN3 is the casting speed of the spell, we add it because the spell will take place
+		 after ARGN3 seconds. If you are using PRECAST you probably don't need to add ARGN3.(Issue #241)

--- a/src/game/CServerConfig.cpp
+++ b/src/game/CServerConfig.cpp
@@ -48,6 +48,7 @@ CServerConfig::CServerConfig()
 
 	//Magic
     m_fManaLossFail		    = false;
+	m_fNPCCanFizzle			= false;
 	m_fReagentLossFail		= false;
     m_fReagentsRequired		= false;
 	m_iWordsOfPowerColor	= HUE_TEXT_DEF;
@@ -567,6 +568,7 @@ enum RC_TYPE
 	RC_NOTOTIMEOUT,
 	RC_NOWEATHER,				// m_fNoWeather
 	RC_NPCAI,					// m_iNpcAi
+	RC_NPCCANFIZZLE,			// m_fNPCCanFizzle
 	RC_NPCNOFAMETITLE,			// m_NPCNoFameTitle
 	RC_NPCSKILLSAVE,			// m_iSaveNPCSkills
 	RC_NPCTRAINCOST,			// m_iTrainSkillCost
@@ -813,6 +815,7 @@ const CAssocReg CServerConfig::sm_szLoadKeys[RC_QTY+1] =
 	{ "NOTOTIMEOUT",			{ ELEM_INT,		OFFSETOF(CServerConfig,m_iNotoTimeout),			0 }},
 	{ "NOWEATHER",				{ ELEM_BOOL,	OFFSETOF(CServerConfig,m_fNoWeather),			0 }},
 	{ "NPCAI",					{ ELEM_INT,		OFFSETOF(CServerConfig,m_iNpcAi),				0 }},
+	{ "NPCCANFIZZLE",			{ ELEM_BOOL,	OFFSETOF(CServerConfig,m_fNPCCanFizzle),		0 }},
 	{ "NPCNOFAMETITLE",			{ ELEM_BOOL,	OFFSETOF(CServerConfig,m_NPCNoFameTitle),		0 }},
 	{ "NPCSKILLSAVE",			{ ELEM_INT,		OFFSETOF(CServerConfig,m_iSaveNPCSkills),		0 }},
 	{ "NPCTRAINCOST",			{ ELEM_INT,		OFFSETOF(CServerConfig,m_iTrainSkillCost),		0 }},

--- a/src/game/CServerConfig.cpp
+++ b/src/game/CServerConfig.cpp
@@ -48,7 +48,7 @@ CServerConfig::CServerConfig()
 
 	//Magic
     m_fManaLossFail		    = false;
-	m_fNPCCanFizzle			= false;
+	m_fNPCCanFizzleOnHit	= false;
 	m_fReagentLossFail		= false;
     m_fReagentsRequired		= false;
 	m_iWordsOfPowerColor	= HUE_TEXT_DEF;
@@ -568,7 +568,7 @@ enum RC_TYPE
 	RC_NOTOTIMEOUT,
 	RC_NOWEATHER,				// m_fNoWeather
 	RC_NPCAI,					// m_iNpcAi
-	RC_NPCCANFIZZLE,			// m_fNPCCanFizzle
+	RC_NPCCANFIZZLEONHIT,		// m_fNPCCanFizzle
 	RC_NPCNOFAMETITLE,			// m_NPCNoFameTitle
 	RC_NPCSKILLSAVE,			// m_iSaveNPCSkills
 	RC_NPCTRAINCOST,			// m_iTrainSkillCost
@@ -815,7 +815,7 @@ const CAssocReg CServerConfig::sm_szLoadKeys[RC_QTY+1] =
 	{ "NOTOTIMEOUT",			{ ELEM_INT,		OFFSETOF(CServerConfig,m_iNotoTimeout),			0 }},
 	{ "NOWEATHER",				{ ELEM_BOOL,	OFFSETOF(CServerConfig,m_fNoWeather),			0 }},
 	{ "NPCAI",					{ ELEM_INT,		OFFSETOF(CServerConfig,m_iNpcAi),				0 }},
-	{ "NPCCANFIZZLE",			{ ELEM_BOOL,	OFFSETOF(CServerConfig,m_fNPCCanFizzle),		0 }},
+	{ "NPCCANFIZZLEONHIT",		{ ELEM_BOOL,	OFFSETOF(CServerConfig,m_fNPCCanFizzleOnHit),		0 }},
 	{ "NPCNOFAMETITLE",			{ ELEM_BOOL,	OFFSETOF(CServerConfig,m_NPCNoFameTitle),		0 }},
 	{ "NPCSKILLSAVE",			{ ELEM_INT,		OFFSETOF(CServerConfig,m_iSaveNPCSkills),		0 }},
 	{ "NPCTRAINCOST",			{ ELEM_INT,		OFFSETOF(CServerConfig,m_iTrainSkillCost),		0 }},

--- a/src/game/CServerConfig.h
+++ b/src/game/CServerConfig.h
@@ -252,7 +252,7 @@ public:
 	bool m_fWordsOfPowerStaff;  // Words of Power for staff.
 	bool m_fEquippedCast;       // Allow casting while equipped.
     bool m_fManaLossFail;       // Lose mana when spell casting failed.
-    bool m_fNPCCanFizzle;       // NPCs can fizzle the spell when hit in combat.
+    bool m_fNPCCanFizzleOnHit;  // NPCs can fizzle the spell when hit in combat.
 	bool m_fReagentLossFail;    // Lose reagents when spell casting failed.
 	int  m_iMagicUnlockDoor;    // 1 in N chance of magic unlock working on doors -- 0 means never.
 	ITEMID_TYPE m_iSpell_Teleport_Effect_NPC;       // ID of the item shown when a NPC teleports.

--- a/src/game/CServerConfig.h
+++ b/src/game/CServerConfig.h
@@ -251,7 +251,8 @@ public:
 	bool m_fWordsOfPowerPlayer; // Words of Power for players.
 	bool m_fWordsOfPowerStaff;  // Words of Power for staff.
 	bool m_fEquippedCast;       // Allow casting while equipped.
-    bool m_fManaLossFail;    // Lose mana when spell casting failed.
+    bool m_fManaLossFail;       // Lose mana when spell casting failed.
+    bool m_fNPCCanFizzle;       // NPCs can fizzle the spell when hit in combat.
 	bool m_fReagentLossFail;    // Lose reagents when spell casting failed.
 	int  m_iMagicUnlockDoor;    // 1 in N chance of magic unlock working on doors -- 0 means never.
 	ITEMID_TYPE m_iSpell_Teleport_Effect_NPC;       // ID of the item shown when a NPC teleports.

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -817,7 +817,7 @@ effect_bounce:
     }
 
 	// Disturb magic spells (only players can be disturbed)
-	if ( m_pPlayer && (pSrc != this) && !(uType & DAMAGE_NODISTURB) && g_Cfg.IsSkillFlag(Skill_GetActive(), SKF_MAGIC) )
+	if ( (m_pPlayer || g_Cfg.m_fNPCCanFizzle) && (pSrc != this) && !(uType & DAMAGE_NODISTURB) && g_Cfg.IsSkillFlag(Skill_GetActive(), SKF_MAGIC) )
 	{
 		// Check if my spell can be interrupted
 		int iDisturbChance = 0;

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -816,8 +816,8 @@ effect_bounce:
         }
     }
 
-	// Disturb magic spells (only players can be disturbed)
-	if ( (m_pPlayer || g_Cfg.m_fNPCCanFizzle) && (pSrc != this) && !(uType & DAMAGE_NODISTURB) && g_Cfg.IsSkillFlag(Skill_GetActive(), SKF_MAGIC) )
+	// Disturb magic spells (only players can be disturbed if NpCCanFizzleOnHit is false in sphere.ini)
+	if ( (m_pPlayer || g_Cfg.m_fNPCCanFizzleOnHit) && (pSrc != this) && !(uType & DAMAGE_NODISTURB) && g_Cfg.IsSkillFlag(Skill_GetActive(), SKF_MAGIC) )
 	{
 		// Check if my spell can be interrupted
 		int iDisturbChance = 0;

--- a/src/game/chars/CCharNPCStatus.cpp
+++ b/src/game/chars/CCharNPCStatus.cpp
@@ -423,9 +423,13 @@ bool CChar::NPC_FightMayCast(bool fCheckSkill) const
 {
 	ADDTOCALLSTACK("CChar::NPC_FightMayCast");
 	ASSERT(m_pNPC);
-	// This NPC could cast spells if they wanted to ?
-	// check mana and anti-magic
-	// Dont check for skill if !fCheckSkill
+	// This NPC could cast spells if they wanted to?
+	// Check mana, anti-magic and tag.noCastTill.
+	// Don't check for skill if !fCheckSkill.
+	
+	//Don't cast the spell if tag.NPCNoCastTill is > than CurrentTime.
+	if (GetKeyNum("NPCNoCastTill") > (g_World.GetCurrentTime().GetTimeRaw() / MSECS_PER_TENTH))
+		return false;
 	if (fCheckSkill && !const_cast<CChar*>(this)->Skill_GetMagicRandom(300))
 		return false;
 	if ( m_pArea && m_pArea->IsFlag(REGION_ANTIMAGIC_DAMAGE|REGION_FLAG_SAFE) )

--- a/src/sphere.ini
+++ b/src/sphere.ini
@@ -880,7 +880,7 @@ WOPStaff=0
 ManaLossFail=0
 
 // NPCs can fizzle the spell when hit in combat.
-NPCCanFizzle=0
+NPCCanFizzleOnHit=0
 
 // Reagents lost if magic fails
 ReagentLossFail=0

--- a/src/sphere.ini
+++ b/src/sphere.ini
@@ -879,6 +879,9 @@ WOPStaff=0
 // Mana lost if magic fails
 ManaLossFail=0
 
+// NPCs can fizzle the spell when hit in combat.
+NPCCanFizzle=0
+
 // Reagents lost if magic fails
 ReagentLossFail=0
 


### PR DESCRIPTION
New ini flag NPCCanFizzle, when enabled, a NPC can fizzle a spell when hit during combat.

TAG.NPCNoCastTill behaviour, this tag will not allow a NPC to cast a spell if tag.NPCNoCastTill > SERV.Time.