### PR TITLE
Issues #486, #482

### DIFF
--- a/src/game/chars/CCharAttacker.cpp
+++ b/src/game/chars/CCharAttacker.cpp
@@ -254,7 +254,6 @@ void CChar::Attacker_Clear()
         }
     }
 
-    StatFlag_Clear(STATF_WAR);  // Combat ended, no need to remain in war mode.
     m_lastAttackers.clear();
     UpdateModeFlag();
 }

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -1181,14 +1181,15 @@ void CChar::Fight_ClearAll()
 		Skill_Start(SKILL_NONE);
 		m_Fight_Targ_UID.InitUID();
 	}
-    Attacker_Clear();
+	
+    	Attacker_Clear();
+	m_atFight.m_iWarSwingState = WAR_SWING_EQUIPPING;
+	m_atFight.m_iRecoilDelay = 0;
+	m_atFight.m_iSwingAnimationDelay = 0;
+	m_atFight.m_iSwingAnimation = 0;
+	m_atFight.m_iSwingIgnoreLastHitTag = 0;
 
-    m_atFight.m_iWarSwingState = WAR_SWING_EQUIPPING;
-    m_atFight.m_iRecoilDelay = 0;
-    m_atFight.m_iSwingAnimationDelay = 0;
-    m_atFight.m_iSwingAnimation = 0;
-    m_atFight.m_iSwingIgnoreLastHitTag = 0;
-
+	StatFlag_Clear(STATF_WAR);
 	UpdateModeFlag();
 }
 

--- a/src/game/clients/CClientEvent.cpp
+++ b/src/game/clients/CClientEvent.cpp
@@ -957,6 +957,7 @@ void CClient::Event_CombatMode( bool fWar ) // Only for switching to combat mode
 	if ( fCleanSkill )
 	{
 		m_pChar->Skill_Fail( true );
+		m_pChar->m_Fight_Targ_UID.InitUID();
 		//DEBUG_WARN(("UserWarMode - Cleaning Skill Action\n"));
 	}
 


### PR DESCRIPTION
Issue #486 
As Fight_ClearAll is only called in NPCs and Attacker_Clear is called on every char, it was removing STATF_War from players and they can handle war/peace in their own paperdoll.
This PR reverts changes from this commit: https://github.com/Sphereserver/Source-X/commit/21c96aa43d588af5b45425660bf3506f35626223#diff-bae9c81930593df52db9fa45b7581378

Issue #482 
Attacker was not cleared when a client used war/peace toggle. Now it is included in ARGN2 along with the skill clear. Admins now can choose if they want to clean the client or not from these internal variables.