### PR TITLE
Update CCMultiMovable.cpp

### DIFF
--- a/src/game/components/CCMultiMovable.cpp
+++ b/src/game/components/CCMultiMovable.cpp
@@ -92,7 +92,9 @@ bool CCMultiMovable::SetMoveDir(DIR_TYPE dir, ShipMovementType eMovementType, bo
 
     // SpeedMode, as supported by the 0xF6 packet (sent from server): 0x01 = one tile, 0x02 = rowboat, 0x03 = slow, 0x04 = fast
     // TODO RowBoat's checks.
-    _eSpeedMode = (eMovementType == SMT_SLOW) ? SMS_SLOW : SMS_FAST;
+    if (fWheelMove)
+        _eSpeedMode = (eMovementType == SMT_SLOW) ? SMS_SLOW : SMS_FAST;
+	
     SetNextMove();
     return true;
 }


### PR DESCRIPTION
Speed mode should only be overwritten when receiving packets to prevent abuse.
This way you can control the speed from scripts.