### PR TITLE
Fix for issue #496: Adding the Blade Spirits spell to a spellbook added the Clumsy spell.

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2276,3 +2276,8 @@ Must have event, even if it's empty, since it's applied by the source to generat
 		1)When combat started, the first @HitTry trigger was fired before the @SkillStart/@Start triggers.
 		  If we were using a custom combat formula and thus overriding  the ACTDIFF in @HitTry, forcing a miss by setting a negative value in ACTDIFF would cause the combat to block.
 		2)When combat started, the chance to hit wasn't calculated so the first hit was always a success because ACTDIFF was set to 0.
+
+23-07-2020, Drk8
+- Fixed: Adding the Blade Spirits spell to a spellbook added the Clumsy spell. (Issue #496)
+		 Warning: existing Spellbooks with the Blade Spirits spell added by scroll or addspell have the more1 value corrupted and so need they must be replaced.
+		 Only Magery Spellbooks are affected because other spellsbooks doesn't have more than 32 spells (Mastery Spells are not implemented).

--- a/src/game/items/CItem.cpp
+++ b/src/game/items/CItem.cpp
@@ -4182,7 +4182,7 @@ bool CItem::IsSpellInBook( SPELL_TYPE spell ) const
 
 	// Convert spell back to format of the book and check whatever it is in
 	const uint i = uint(spell) - (pItemDef->m_ttSpellbook.m_iOffset + 1u);
-	if ( i <= 32 )
+	if ( i < 32 ) //Replaced the <= with < because of the formula above, the first 32 spells have an i value from 0 to 31. 
 		return ((m_itSpellbook.m_spells1 & (1u << i)) != 0);
 	else if ( i <= 64 )
 		return ((m_itSpellbook.m_spells2 & (1u << (i-32))) != 0);
@@ -4267,7 +4267,7 @@ uint CItem::AddSpellbookSpell( SPELL_TYPE spell, bool fUpdate )
 
 	// Add spell to spellbook bitmask
 	const uint i = spell - (pBookDef->m_ttSpellbook.m_iOffset + 1);
-	if ( i <= 32u )
+	if ( i < 32u ) //Replaced the <= with < because of the formula above, the first 32 spells have an i value from 0 to 31. 
 		m_itSpellbook.m_spells1 |= (1 << i);
 	else if ( i <= 64u )
 		m_itSpellbook.m_spells2 |= (1 << (i-32u));

--- a/src/game/items/CItem.cpp
+++ b/src/game/items/CItem.cpp
@@ -4180,11 +4180,11 @@ bool CItem::IsSpellInBook( SPELL_TYPE spell ) const
 	if ( uint(spell) <= pItemDef->m_ttSpellbook.m_iOffset || spell < 0)
 		return false;
 
-	// Convert spell back to format of the book and check whatever it is in
+	// Convert spell back to format of the book and check whatever it is in.
 	const uint i = uint(spell) - (pItemDef->m_ttSpellbook.m_iOffset + 1u);
-	if ( i < 32 ) //Replaced the <= with < because of the formula above, the first 32 spells have an i value from 0 to 31. 
+	if ( i < 32 ) // Replaced the <= with < because of the formula above, the first 32 spells have an i value from 0 to 31 and are stored in more1.
 		return ((m_itSpellbook.m_spells1 & (1u << i)) != 0);
-	else if ( i <= 64 )
+	else if ( i < 64 ) // Replaced the <= with < because of the formula above, the remaining 32 spells have an i value from 32 to 63 and are stored in more2.
 		return ((m_itSpellbook.m_spells2 & (1u << (i-32))) != 0);
 	//else if ( i <= 96 )
 	//	return ((m_itSpellbook.m_spells2 & (1u << (i-64))) != 0);	//not used anymore?
@@ -4265,12 +4265,12 @@ uint CItem::AddSpellbookSpell( SPELL_TYPE spell, bool fUpdate )
 	if ( IsSpellInBook(spell) )
 		return 1;
 
-	// Add spell to spellbook bitmask
+	// Add spell to spellbook bitmask:
 	const uint i = spell - (pBookDef->m_ttSpellbook.m_iOffset + 1);
-	if ( i < 32u ) //Replaced the <= with < because of the formula above, the first 32 spells have an i value from 0 to 31. 
+	if ( i < 32u ) // Replaced the <= with < because of the formula above, the first 32 spells have an i value from 0 to 31 and are stored in more1.
 		m_itSpellbook.m_spells1 |= (1 << i);
-	else if ( i <= 64u )
-		m_itSpellbook.m_spells2 |= (1 << (i-32u));
+	else if ( i < 64u ) // Replaced the <= with < because of the formula above, the remaining 32 spells have an i value from 32 to 63 and are stored in more2.
+		m_itSpellbook.m_spells2 |= (1 << (i-32u)); 
 	//else if ( i <= 96 )
 	//	m_itSpellbook.m_spells3 |= (1 << (i-64));	//not used anymore?
 	else


### PR DESCRIPTION
This also caused a corruption of the more1 value of the spellbooks, probably causing the disappearance of the rest of the spells?
They will have to replace players spellbooks i guess