### PR TITLE
Possible Fix for issue #499 : Cant create areas in the new maps (ilshenar, ter mur, etc)

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2281,3 +2281,6 @@ Must have event, even if it's empty, since it's applied by the source to generat
 - Fixed: Adding the Blade Spirits spell to a spellbook added the Clumsy spell. (Issue #496)
 		 Warning: existing Spellbooks with the Blade Spirits spell added by scroll or addspell have the more1 value corrupted and so need they must be replaced.
 		 Only Magery Spellbooks are affected because other spellsbooks doesn't have more than 32 spells (Mastery Spells are not implemented).
+		 
+29-08-2020, Drk84
+- Fixed: Cant create areas in the new maps (ilshenar, ter mur, etc) (Issue  #499)

--- a/src/game/CSectorList.cpp
+++ b/src/game/CSectorList.cpp
@@ -28,9 +28,16 @@ void CSectorList::Init()
 	// Initialize sector data for every map plane
 	TemporaryString ts;
 	TemporaryString tsConcat;
-	int iSectorIndex = 0;
+	
 	for (int iMap = 0; iMap < MAP_SUPPORTED_QTY; ++iMap)
 	{
+		/*
+			Before iSectorIndex was declared and set to 0 outside the FOR, so I moved it inside because
+			we need to (re)set iSectorIndex to 0 when Sphere finish to initialize every sectors in a map, otherwise
+			iSectorIndex will have the same value of iSectorQty when Sphere finish loading map0.
+		*/
+		int iSectorIndex = 0;
+
 		MapSectorsData& sd = _SectorData[iMap];
 		sd._iSectorSize = sd._iSectorColumns = sd._iSectorRows = sd._iSectorQty = 0;
 		sd._pSectors.release();
@@ -63,6 +70,7 @@ void CSectorList::Init()
 			ASSERT(pSector);
 			pSector->Init(iSectorIndex, (uchar)iMap, iSectorX, iSectorY);
 		}
+		
 	}
 
 	for (MapSectorsData& sd : _SectorData)


### PR DESCRIPTION

The AREADEF were loaded correctly, even the new ones, infact you could access the various property by using serv.areadef.defname.xx

It seems that the problem was caused in the method CSectorList::Init(), there the variable:

`int iSectorIndex = 0;`

was declared outside the following FOR cycle

`for (int iMap = 0; iMap < MAP_SUPPORTED_QTY; ++iMap)`

Inside this cycle there is another FOR that initialize every sector of the map Sphere is currently looping

`for (; iSectorIndex < iSectorQty; ++iSectorIndex)`

After this cycle ends, Sphere will loop through the next map and try again to initialize its sectors but because iSectorIndex was not reset to 0 at the end of the map loop, the sector cycle will fail because iSectorIndex would have already the value of iSectorQty from the previous map cycle.