### PR TITLE
Fix  the Fixweight function

### DIFF
--- a/src/game/CContainer.cpp
+++ b/src/game/CContainer.cpp
@@ -99,8 +99,11 @@ int CContainer::FixWeight()
 	{
 		CItemContainer *pCont = dynamic_cast<CItemContainer *>(pObjRec);
 		if (!pCont)
+		{
+			CItem *pItem = dynamic_cast<CItem *>(pObjRec);
+			m_totalweight += pItem->GetWeight();
 			continue;
-
+		}
         pCont->FixWeight();
         if (!pCont->IsWeighed())	// bank box doesn't count for weight.
             continue;


### PR DESCRIPTION
The function was not working correctly. 

Like it show on the issue #502, after the function was lauch, the weight was dropping.
The probleme was because only the weight of the container was calculate and not the item on them.
Thx to DRK84 for helping me

Fix for this issue: #502