### PR TITLE
Fix for Water type ITEM go nevermovable on save (issue #483)

### DIFF
--- a/src/game/items/CItem.cpp
+++ b/src/game/items/CItem.cpp
@@ -835,11 +835,15 @@ int CItem::FixWeirdness()
         ClrAttr(ATTR_CURSED | ATTR_CURSED2 | ATTR_BLESSED | ATTR_BLESSED2);
     }
 
+	// Don't know why this check is done.
     if (IsMovableType())
     {
         if (IsType(IT_WATER) || Can(CAN_I_WATER))
         {
-            SetAttr(ATTR_MOVE_NEVER);
+			if ( ! IsAttr(ATTR_MOVE_ALWAYS))	// If item is explicitely set to always movable, it will not lock it.
+			{
+	            SetAttr(ATTR_MOVE_NEVER);
+			}
         }
     }
 

--- a/src/game/items/CItem.cpp
+++ b/src/game/items/CItem.cpp
@@ -835,15 +835,14 @@ int CItem::FixWeirdness()
         ClrAttr(ATTR_CURSED | ATTR_CURSED2 | ATTR_BLESSED | ATTR_BLESSED2);
     }
 
-	// Don't know why this check is done.
     if (IsMovableType())
     {
         if (IsType(IT_WATER) || Can(CAN_I_WATER))
         {
-			if ( ! IsAttr(ATTR_MOVE_ALWAYS))	// If item is explicitely set to always movable, it will not lock it.
-			{
+		if ( ! IsAttr(ATTR_MOVE_ALWAYS))	// If item is explicitely set to always movable, it will not lock it.
+		{
 	            SetAttr(ATTR_MOVE_NEVER);
-			}
+		}
         }
     }
 


### PR DESCRIPTION
This solution FIX the issue https://github.com/Sphereserver/Source-X/issues/483.

Each save, there a called function "FixWeirdness()" . This fonction certainly have his reason and seem to fix few anomaly and strange exploit that can occur.

One particular verification checking if we can deplace type water item: ` if (IsType(IT_WATER) || Can(CAN_I_WATER))`

If yes, the item is automaticaly locked down.

I added a verification if item is EXPLICITELY set to ALWAYS movable, item will not be locked down.

On 56d and 55i, water through was not lock at each save with this modif, I'll set all my player's water through to Always movable .

