### PR TITLE
FIX personnal space message when invisible (Issue #463)

### DIFF
--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -3411,8 +3411,10 @@ CRegion * CChar::CanMoveWalkTo( CPointMap & ptDst, bool fCheckChars, bool fCheck
 			else if ( pChar->IsStatFlag(STATF_SLEEPING) )
 				snprintf(pszMsg, STR_TEMPLENGTH, g_Cfg.GetDefaultMsg(DEFMSG_MSG_STEPON_BODY), pChar->GetName());
 			else
-				snprintf(pszMsg, STR_TEMPLENGTH, g_Cfg.GetDefaultMsg(DEFMSG_MSG_PUSH), pChar->GetName());
-
+				if (!pChar->IsStatFlag(STATF_INVISIBLE))
+				{
+					snprintf(pszMsg, STR_TEMPLENGTH, g_Cfg.GetDefaultMsg(DEFMSG_MSG_PUSH), pChar->GetName());
+				}
 			if ( iRet != TRIGRET_RET_FALSE )
 				SysMessage(pszMsg);
 


### PR DESCRIPTION
Like it's explain on this issue: https://github.com/Sphereserver/Source-X/issues/463.

When Walking on someone invisible and Setting is set, your not suppose to have a message:
`// REVEALF_OSILIKEPERSONALSPACE		0020	// Do not reveal when a character enters on personal space (and do not send any message).`

For now, you have a message.

I just added a restriction if the player is invisible it's not show message. IF REVEALF_OSILIKEPERSONALSPACE is not activated, the character is already reveal at this line.
