### PR TITLE
Modify context menu on NPC: Gm can now control ALL NPC

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2284,3 +2284,6 @@ Must have event, even if it's empty, since it's applied by the source to generat
 		 
 29-08-2020, Drk84
 - Fixed: Cant create areas in the new maps (ilshenar, ter mur, etc) (Issue  #499)
+
+25-09-2020, jhobean
+- Modified: GM can now prompt context menu from NPC and command them. (Ex: Kill follow, guard, etc)

--- a/src/game/clients/CClientEvent.cpp
+++ b/src/game/clients/CClientEvent.cpp
@@ -2477,7 +2477,7 @@ void CClient::Event_AOSPopupMenuRequest( dword uid ) //construct packet after a 
 			else
 			{
 				word iEnabled = pChar->IsStatFlag(STATF_DEAD) ? POPUPFLAG_LOCKED : POPUPFLAG_COLOR;
-				if ((pChar->IsOwnedBy(m_pChar, false)) && (pChar->m_pNPC->m_Brain != NPCBRAIN_BERSERK))
+				if ( (pChar->IsOwnedBy(m_pChar, false)) && ((pChar->m_pNPC->m_Brain != NPCBRAIN_BERSERK)) || (m_pChar->IsPriv(PRIV_GM)))
 				{
 					CREID_TYPE id = pChar->GetID();
 

--- a/src/game/clients/CClientEvent.cpp
+++ b/src/game/clients/CClientEvent.cpp
@@ -2477,7 +2477,7 @@ void CClient::Event_AOSPopupMenuRequest( dword uid ) //construct packet after a 
 			else
 			{
 				word iEnabled = pChar->IsStatFlag(STATF_DEAD) ? POPUPFLAG_LOCKED : POPUPFLAG_COLOR;
-				if ( (pChar->IsOwnedBy(m_pChar, false)) && ((pChar->m_pNPC->m_Brain != NPCBRAIN_BERSERK)) || (m_pChar->IsPriv(PRIV_GM)))
+				if ( (pChar->IsOwnedBy(m_pChar, false)) && ((pChar->m_pNPC->m_Brain != NPCBRAIN_BERSERK)) || (pChar->IsPriv(PRIV_GM)))
 				{
 					CREID_TYPE id = pChar->GetID();
 


### PR DESCRIPTION
On 56d there was a feature where Gm can control NPC without speaking:
![image](https://user-images.githubusercontent.com/51728381/94303829-74bebf80-ff3c-11ea-88df-816a683019f2.png)


It's usefull during animation because you can easily ask some NPC to attack or Guard someone.