### PR TITLE
Fix for PR #522. Same plevel player was seeing each other

### DIFF
--- a/src/game/chars/CCharStatus.cpp
+++ b/src/game/chars/CCharStatus.cpp
@@ -1188,34 +1188,40 @@ bool CChar::CanSee( const CObjBaseTemplate *pObj ) const
 					return ( Args.m_iN1 != 1 );
 				}
 			}
-
-			switch (g_Cfg.m_iCanSeeSamePLevel) //Evaluate the .ini setting
+			//Here we analyse how GM can see other player/GM when they are hide.
+			if (plevelMe < 2) //only Plevel over 2 have the possibility to see other
 			{
-			case 0: //GM see all
-				if (plevelMe < plevelChar)
-				{
-					return false;
-				}
-				break;
-			case 1: //Gm dont see same plevel
-				if (plevelMe <= plevelChar)
-				{
-					return false;
-				}
-				break;
-			case 2: //Plevel x and more see all
-			case 3:
-			case 4:
-			case 5:
-			case 6:
-			case 7:
-				if (plevelMe < g_Cfg.m_iCanSeeSamePLevel)
-				{
-					return false;
-				}
-				break;
+				return false;
 			}
-
+			else
+			{
+				switch (g_Cfg.m_iCanSeeSamePLevel) //Evaluate the .ini setting
+				{
+				case 0: //GM see all
+					if (plevelMe < plevelChar)
+					{
+						return false;
+					}
+					break;
+				case 1: //Gm dont see same plevel
+					if (plevelMe <= plevelChar)
+					{
+						return false;
+					}
+					break;
+				case 2: //Plevel x and more see all
+				case 3:
+				case 4:
+				case 5:
+				case 6:
+				case 7:
+					if (plevelMe < g_Cfg.m_iCanSeeSamePLevel)
+					{
+						return false;
+					}
+					break;
+				}
+			}
 		}
 
 		if ( IsStatFlag(STATF_DEAD) && !CanSeeAsDead(pChar) )


### PR DESCRIPTION
On the PR #522  Fixing the issue #506  There was 1 littles bug.

Plevel 0 player with same Plevel was able to see each other.

I just added a verification where Plevel 0 and 1 don't see other player except if the trigger ask it.