### PR TITLE
Fixed: Dismounting from a NPC cleared the actarg1 value of the rider …

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2299,3 +2299,8 @@ Must have event, even if it's empty, since it's applied by the source to generat
 
 11-11-2020, Jhobean
 - Fixed: Animal Taming skill not checking follower slots limit when OF_PetSlots is enabled. (Issue  #534)
+
+20-11-2020, Drk84
+- Fixed: Dismounting from a NPC cleared the actarg1 value of the rider instead of the NPC mount. (Issue #527)
+		 This means that when unmounting and the character is using a skill that makes use of the Actarg1 value, such  as casting a spell, the skill will continue its execution normally. 
+- Fixed: Invalid spell ID didn't abort the skill execution when the magic skill succeeds (this is related to the issue above), causing a possible skill gain.

--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -2783,7 +2783,14 @@ bool CChar::Horse_UnMount()
 	{
 		Use_Figurine(pMountItem, false);
 		pMountItem->Delete();
-        m_atRidden.m_uidFigurine.InitUID();
+		/*
+		Actarg1 holds the UID of the mount item when the NPC is being ridden and as we can see in the Horse_GetMountItem method
+		this actarg1 value is stored in the NPC not in the player.
+		The commented  line below cleared the actarg1 of the rider instead of the NPC mount.
+		*/
+        //m_atRidden.m_uidFigurine.InitUID(); 
+		if (pPet && !pPet->IsDeleted())
+			pPet->m_atRidden.m_uidFigurine.InitUID(); //This clears the actarg1 of the NPC mount instead of the rider.
 	}
 	return true;
 }

--- a/src/game/chars/CCharSkill.cpp
+++ b/src/game/chars/CCharSkill.cpp
@@ -2695,7 +2695,7 @@ int CChar::Skill_Magery( SKTRIG_TYPE stage )
 	{
 		const CSpellDef * tSpell = g_Cfg.GetSpellDef( m_atMagery.m_iSpell );
 		if (tSpell == nullptr)
-			return 0;
+			return -SKTRIG_ABORT; //Before we returned 0, thus allowing the skill to continue its execution and possible gaining a skill increase when the spell ID was invalid.
 
 		if ( IsClientActive() && IsSetMagicFlags( MAGICF_PRECAST ) && !tSpell->IsSpellType( SPELLFLAG_NOPRECAST ))
 		{


### PR DESCRIPTION
…instead of the NPC mount. (Issue #527)
Fixed: Invalid spell ID didn't abort the skill execution when the magic skill succeeds (this is related to the issue above), causing a possible skill gain.

When a NPC mount is mounted, this NPC will holds the UID of the mount item (stored in the rider layer) in its Actarg1 value (as we can see in the Horse_GetMountItem method),
but when the NPC mount is dismounted the Actarg1 of the rider is cleared instead of the NPC mount.

This caused a problem when the rider was performing a skill that make uses of actarg1 (such as a casting a spell) and quickly dismounting:
In the case of a magic skill, actarg1 holds the spell ID, and by clearing this value when dismounting, it caused the spell to halt.
Combined with problem above, a wrong return value aloing with an invalid spell ID in the Skill_Magery method, didn't abort the skill success execution, allowing a player to increase the magic skill score without the spell consuming mana / reagents.