### PR TITLE
Add possibility to see invis item with the color Grey (Feature request #537)

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2304,3 +2304,7 @@ Must have event, even if it's empty, since it's applied by the source to generat
 - Fixed: Dismounting from a NPC cleared the actarg1 value of the rider instead of the NPC mount. (Issue #527)
 		 This means that when unmounting and the character is using a skill that makes use of the Actarg1 value, such  as casting a spell, the skill will continue its execution normally. 
 - Fixed: Invalid spell ID didn't abort the skill execution when the magic skill succeeds (this is related to the issue above), causing a possible skill gain.
+
+26-11-2020, Jhobean
+- Added: OF_ColorInvisItem ini option allow to see invis item in grey color. (feature request #537)
+This will help GM to make difference of invis or not invis item. The color can be change with the ColorInvis= setting.

--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2306,5 +2306,6 @@ Must have event, even if it's empty, since it's applied by the source to generat
 - Fixed: Invalid spell ID didn't abort the skill execution when the magic skill succeeds (this is related to the issue above), causing a possible skill gain.
 
 26-11-2020, Jhobean
-- Added: ColorInvisItem ini option allow to see invis item in different color. (feature request #537)
-This will help GM to make difference of invis or not invis item. Color can be change this way 04001 = transparent color, 0 = default item color , 1000 = Grey color
+- Added: ColorInvisItem ini option allow to see invis item in different color (feature request #537).
+		This will help GM to make difference of invis or not invis item. Color can be change this way 
+		ColorInvisItem = (0 = default item color , 01 to 04001 = custom color, 1000 = Invis Grey color)

--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2306,5 +2306,5 @@ Must have event, even if it's empty, since it's applied by the source to generat
 - Fixed: Invalid spell ID didn't abort the skill execution when the magic skill succeeds (this is related to the issue above), causing a possible skill gain.
 
 26-11-2020, Jhobean
-- Added: OF_ColorInvisItem ini option allow to see invis item in grey color. (feature request #537)
-This will help GM to make difference of invis or not invis item. The color can be change with the ColorInvis= setting.
+- Added: ColorInvisItem ini option allow to see invis item in different color. (feature request #537)
+This will help GM to make difference of invis or not invis item. Color can be change this way 04001 = transparent color, 0 = default item color , 1000 = Grey color

--- a/src/game/CObjBase.h
+++ b/src/game/CObjBase.h
@@ -568,7 +568,7 @@ public:
      *
      * @return  The hue.
      */
-	HUE_TYPE GetHue() const;
+	virtual HUE_TYPE GetHue() const;
 
 protected:
 

--- a/src/game/CObjBase.h
+++ b/src/game/CObjBase.h
@@ -29,7 +29,7 @@ class CObjBase : public CObjBaseTemplate, public CScriptObj, public CEntity, pub
 
 private:
 	int64 m_timestamp;          // TimeStamp
-	HUE_TYPE m_wHue;			// Hue or skin color. (CItems must be < 0x4ff or so)
+	HUE_TYPE m_wHue;			// Hue or skin color.
 
 protected:
 	CResourceRef m_BaseRef;     // Pointer to the resource that describes this type.

--- a/src/game/CObjBase.h
+++ b/src/game/CObjBase.h
@@ -29,7 +29,7 @@ class CObjBase : public CObjBaseTemplate, public CScriptObj, public CEntity, pub
 
 private:
 	int64 m_timestamp;          // TimeStamp
-	HUE_TYPE m_wHue;			// Hue or skin color.
+    
 
 protected:
 	CResourceRef m_BaseRef;     // Pointer to the resource that describes this type.
@@ -42,6 +42,7 @@ public:
     static const char *m_sClassName;
     static dword sm_iCount;    // how many total objects in the world ?
 
+    
     int _iCreatedResScriptIdx;	// index in g_Cfg.m_ResourceFiles of the script file where this obj was created
     int _iCreatedResScriptLine;	// line in the script file where this obj was created
 
@@ -55,7 +56,7 @@ public:
     word	m_defenseBase;	    // Armor for IsArmor items
     word	m_defenseRange;     // variable range of defense.
     int 	m_ModMaxWeight;		// ModMaxWeight prop.
-
+    HUE_TYPE m_wHue;			// Hue or skin color. (CItems must be < 0x4ff or so)
     CUID 	_uidSpawn;          // SpawnItem for this item
 
     CResourceRefArray m_OEvents;

--- a/src/game/CServerConfig.cpp
+++ b/src/game/CServerConfig.cpp
@@ -269,6 +269,7 @@ CServerConfig::CServerConfig()
 	m_iColorNotoInvulGameMaster = 0x0b;		// purple
 	m_iColorNotoDefault			= 0x3b2;	// grey (if not any other)
 
+	m_iColorInvisItem   = 1000;
 	m_iColorInvis		= 0;
 	m_iColorInvisSpell	= 0;
 	m_iColorHidden		= 0;
@@ -440,6 +441,7 @@ enum RC_TYPE
 	RC_CLIENTS,
 	RC_COLORHIDDEN,
 	RC_COLORINVIS,
+	RC_COLORINVISITEM,
 	RC_COLORINVISSPELL,
 	RC_COLORNOTOCRIMINAL,		// m_iColorNotoCriminal
 	RC_COLORNOTODEFAULT,		// m_iColorNotoDefault
@@ -690,6 +692,7 @@ const CAssocReg CServerConfig::sm_szLoadKeys[RC_QTY+1] =
 	{ "CLIENTS",				{ ELEM_VOID,	0,											    0 }},	// duplicate
 	{ "COLORHIDDEN",			{ ELEM_VOID,	OFFSETOF(CServerConfig,m_iColorHidden),			0 }},
 	{ "COLORINVIS",				{ ELEM_VOID,	OFFSETOF(CServerConfig,m_iColorInvis),			0 }},
+	{ "COLORINVISITEM",			{ ELEM_VOID,	OFFSETOF(CServerConfig,m_iColorInvisItem),		0 }},
 	{ "COLORINVISSPELL",		{ ELEM_VOID,	OFFSETOF(CServerConfig,m_iColorInvisSpell),		0 }},
 	{ "COLORNOTOCRIMINAL",		{ ELEM_WORD,	OFFSETOF(CServerConfig,m_iColorNotoCriminal),	0 }},
 	{ "COLORNOTODEFAULT",		{ ELEM_WORD,	OFFSETOF(CServerConfig,m_iColorNotoDefault),	0 }},
@@ -1075,6 +1078,9 @@ bool CServerConfig::r_LoadVal( CScript &s )
 			break;
 		case RC_COLORINVIS:
 			m_iColorInvis = (HUE_TYPE)(s.GetArgVal());
+			break;
+		case RC_COLORINVISITEM:
+			m_iColorInvisItem = (HUE_TYPE)(s.GetArgVal());
 			break;
 		case RC_COLORINVISSPELL:
 			m_iColorInvisSpell = (HUE_TYPE)(s.GetArgVal());
@@ -1837,6 +1843,9 @@ bool CServerConfig::r_WriteVal( lpctstr ptcKey, CSString & sVal, CTextConsole * 
 			break;
 		case RC_COLORINVIS:
 			sVal.FormatHex( m_iColorInvis );
+			break;
+		case RC_COLORINVISITEM:
+			sVal.FormatHex( m_iColorInvisItem );
 			break;
 		case RC_COLORINVISSPELL:
 			sVal.FormatHex( m_iColorInvisSpell );
@@ -4185,7 +4194,6 @@ void CServerConfig::PrintEFOFFlags(bool bEF, bool bOF, CTextConsole *pSrc)
         if ( IsSetOF(OF_StatAllowValOverMax) )		catresname(zOptionFlags, "StatAllowValOverMax");
         if ( IsSetOF(OF_GuardOutsideGuardedArea) )	catresname(zOptionFlags, "GuardOutsideGuardedArea");
         if ( IsSetOF(OF_OWNoDropCarriedItem) )		catresname(zOptionFlags, "OWNoDropCarriedItem");
-		if ( IsSetOF(OF_ColorInvisItem) )			catresname(zOptionFlags, "ColorInvisItem");
 
 		if ( zOptionFlags[0] != '\0' )
 		{

--- a/src/game/CServerConfig.cpp
+++ b/src/game/CServerConfig.cpp
@@ -4185,6 +4185,7 @@ void CServerConfig::PrintEFOFFlags(bool bEF, bool bOF, CTextConsole *pSrc)
         if ( IsSetOF(OF_StatAllowValOverMax) )		catresname(zOptionFlags, "StatAllowValOverMax");
         if ( IsSetOF(OF_GuardOutsideGuardedArea) )	catresname(zOptionFlags, "GuardOutsideGuardedArea");
         if ( IsSetOF(OF_OWNoDropCarriedItem) )		catresname(zOptionFlags, "OWNoDropCarriedItem");
+		if ( IsSetOF(OF_ColorInvisItem) )			catresname(zOptionFlags, "ColorInvisItem");
 
 		if ( zOptionFlags[0] != '\0' )
 		{

--- a/src/game/CServerConfig.h
+++ b/src/game/CServerConfig.h
@@ -58,7 +58,8 @@ enum OF_TYPE
     OF_NoTargTurn				= 0x0080000,    // Don't turn the player when targetting something
     OF_StatAllowValOverMax      = 0x0100000,    // Allow stats value above their maximum value (i.e. allow hits value > maxhits).
     OF_GuardOutsideGuardedArea  = 0x0200000,    // Allow guards to walk in unguarded areas, instead of being teleported back to their home point.
-    OF_OWNoDropCarriedItem      = 0x0400000     // When overweighted, don't drop items on ground when moving them (or using BOUNCE) and checking if you can carry them.
+    OF_OWNoDropCarriedItem      = 0x0400000,    // When overweighted, don't drop items on ground when moving them (or using BOUNCE) and checking if you can carry them.
+    OF_ColorInvisItem			= 0x0800000     // Invisible item have a hue and GM can easily know they are invis.
 };
 
 /**

--- a/src/game/CServerConfig.h
+++ b/src/game/CServerConfig.h
@@ -58,8 +58,7 @@ enum OF_TYPE
     OF_NoTargTurn				= 0x0080000,    // Don't turn the player when targetting something
     OF_StatAllowValOverMax      = 0x0100000,    // Allow stats value above their maximum value (i.e. allow hits value > maxhits).
     OF_GuardOutsideGuardedArea  = 0x0200000,    // Allow guards to walk in unguarded areas, instead of being teleported back to their home point.
-    OF_OWNoDropCarriedItem      = 0x0400000,    // When overweighted, don't drop items on ground when moving them (or using BOUNCE) and checking if you can carry them.
-    OF_ColorInvisItem			= 0x0800000     // Invisible item have a hue and GM can easily know they are invis.
+    OF_OWNoDropCarriedItem      = 0x0400000     // When overweighted, don't drop items on ground when moving them (or using BOUNCE) and checking if you can carry them.
 };
 
 /**
@@ -485,6 +484,7 @@ public:
 	HUE_TYPE m_iColorNotoInvulGameMaster;// Purple
 	HUE_TYPE m_iColorNotoDefault;       // Grey
 
+    HUE_TYPE m_iColorInvisItem;	// 04001 = transparent color, 0 = default item color , 1000 = Grey color (Define how the invis item are see by GM)
 	HUE_TYPE m_iColorInvis;     // 04001 = transparent color, 0 = default
 	HUE_TYPE m_iColorInvisSpell;// 04001 = transparent color, 0 = default (This one is for s_invisibility spell, this includes the invis potion.)
 	HUE_TYPE m_iColorHidden;    // 04001 = transparent color, 0 = default

--- a/src/game/items/CItem.cpp
+++ b/src/game/items/CItem.cpp
@@ -1900,6 +1900,15 @@ bool CItem::SetName( lpctstr pszName )
 	return SetNamePool( pszName );
 }
 
+HUE_TYPE CItem::GetHue() const
+{
+
+	if (IsAttr(ATTR_INVIS))
+		return(05);
+
+	return(m_wHue);
+}
+
 int CItem::GetWeight(word amount) const
 {
 	int iWeight = m_weight * (amount ? amount : GetAmount());

--- a/src/game/items/CItem.cpp
+++ b/src/game/items/CItem.cpp
@@ -1901,13 +1901,12 @@ bool CItem::SetName( lpctstr pszName )
 	return SetNamePool( pszName );
 }
 
-HUE_TYPE CItem::GetHue() const
+HUE_TYPE CItem::GetHue() const  //Override of CObjBase::GetHue()
 {
 	if (g_Cfg.m_iColorInvisItem) //If setting ask a specific color
 	{
 		if (IsAttr(ATTR_INVIS))
 			return(g_Cfg.m_iColorInvisItem);
-
 	}
 	
 	return(CObjBase::m_wHue);

--- a/src/game/items/CItem.cpp
+++ b/src/game/items/CItem.cpp
@@ -134,6 +134,8 @@ CItem::CItem( ITEMID_TYPE id, CItemBase * pItemDef ) : CTimedObject(PROFILE_ITEM
 	m_containedGridIndex = 0;
 	m_dwDispIndex = ITEMID_NOTHING;
 
+	m_wHue = HUE_DEFAULT;
+
 	m_itNormal.m_more1 = 0;
 	m_itNormal.m_more2 = 0;
 	m_itNormal.m_morep.ZeroPoint();
@@ -1902,10 +1904,17 @@ bool CItem::SetName( lpctstr pszName )
 
 HUE_TYPE CItem::GetHue() const
 {
-
-	if (IsAttr(ATTR_INVIS))
-		return(05);
-
+	if (IsSetOF(OF_ColorInvisItem)) //Setting to permit GM to see invis item on particular color
+	{
+		if (IsAttr(ATTR_INVIS))
+		{
+			if (g_Cfg.m_iColorInvis)
+				return(g_Cfg.m_iColorInvis);
+			else
+				return(1000); //Color Ghost's Gray
+		}
+	}
+	
 	return(m_wHue);
 }
 

--- a/src/game/items/CItem.cpp
+++ b/src/game/items/CItem.cpp
@@ -134,7 +134,6 @@ CItem::CItem( ITEMID_TYPE id, CItemBase * pItemDef ) : CTimedObject(PROFILE_ITEM
 	m_containedGridIndex = 0;
 	m_dwDispIndex = ITEMID_NOTHING;
 
-	m_wHue = HUE_DEFAULT;
 
 	m_itNormal.m_more1 = 0;
 	m_itNormal.m_more2 = 0;
@@ -1904,18 +1903,14 @@ bool CItem::SetName( lpctstr pszName )
 
 HUE_TYPE CItem::GetHue() const
 {
-	if (IsSetOF(OF_ColorInvisItem)) //Setting to permit GM to see invis item on particular color
+	if (g_Cfg.m_iColorInvisItem) //If setting ask a specific color
 	{
 		if (IsAttr(ATTR_INVIS))
-		{
-			if (g_Cfg.m_iColorInvis)
-				return(g_Cfg.m_iColorInvis);
-			else
-				return(1000); //Color Ghost's Gray
-		}
+			return(g_Cfg.m_iColorInvisItem);
+
 	}
 	
-	return(m_wHue);
+	return(CObjBase::m_wHue);
 }
 
 int CItem::GetWeight(word amount) const

--- a/src/game/items/CItem.h
+++ b/src/game/items/CItem.h
@@ -58,8 +58,7 @@ public:
 	CUID GetLockDownOfMulti() const;
     void SetComponentOfMulti(const CUID& uidMulti);
     void SetLockDownOfMulti(const CUID& uidMulti);
-	
-	HUE_TYPE m_wHue;			// (CItems hue must be < 0x4ff )
+
 	byte	m_speed;
 
 // Attribute flags.

--- a/src/game/items/CItem.h
+++ b/src/game/items/CItem.h
@@ -58,8 +58,8 @@ public:
 	CUID GetLockDownOfMulti() const;
     void SetComponentOfMulti(const CUID& uidMulti);
     void SetLockDownOfMulti(const CUID& uidMulti);
-	HUE_TYPE m_wHue;			// (CItems must be < 0x4ff or so)
-
+	
+	HUE_TYPE m_wHue;			// (CItems hue must be < 0x4ff )
 	byte	m_speed;
 
 // Attribute flags.
@@ -587,7 +587,7 @@ public:
     byte GetRangeH() const;
 
 	/**
-  * @fn  HUE_TYPE CObjBase::GetHue() const;
+  * @fn  HUE_TYPE GetHue() const;
   *
   * @brief   Gets the hue.
   *

--- a/src/game/items/CItem.h
+++ b/src/game/items/CItem.h
@@ -58,6 +58,7 @@ public:
 	CUID GetLockDownOfMulti() const;
     void SetComponentOfMulti(const CUID& uidMulti);
     void SetLockDownOfMulti(const CUID& uidMulti);
+	HUE_TYPE m_wHue;			// (CItems must be < 0x4ff or so)
 
 	byte	m_speed;
 
@@ -584,6 +585,15 @@ public:
     * @return  Value.
     */
     byte GetRangeH() const;
+
+	/**
+  * @fn  HUE_TYPE CObjBase::GetHue() const;
+  *
+  * @brief   Gets the hue.
+  *
+  * @return  The hue.
+  */
+	HUE_TYPE GetHue() const;
 
 	void SetAttr(uint64 uiAttr)
 	{

--- a/src/game/items/CItem.h
+++ b/src/game/items/CItem.h
@@ -592,7 +592,7 @@ public:
   *
   * @return  The hue.
   */
-	HUE_TYPE GetHue() const;
+	virtual HUE_TYPE GetHue() const override;
 
 	void SetAttr(uint64 uiAttr)
 	{

--- a/src/sphere.ini
+++ b/src/sphere.ini
@@ -685,7 +685,7 @@ AdvancedLos=0
 //ColorNotoInvulGameMaster=0b	// purple
 //ColorNotoDefault=03b2		// grey (if not any other)
 
-ColorInvis=0			// 04001 = transparent color, 0 = default
+ColorInvis=0			// 04001 = transparent color, 0 = default (Including invis item see by GM)
 ColorInvisSpell=0		// 04001 = transparent color, 0 = default (This one is for s_invisibility spell, this includes the invis potion.)
 ColorHidden=0			// 04001 = transparent color, 0 = default
 
@@ -764,6 +764,7 @@ Experimental=0
 // OF_StatAllowValOverMax		00100000 // Allow stats value above their maximum value (i.e. allow hits value > maxhits).
 // OF_GuardOutsideGuardedArea   00200000 // Allow guards to walk in unguarded areas, instead of being teleported back to their home point.
 // OF_OWNoDropCarriedItem		00400000 // When overweighted, don't drop items on ground when moving them (or using BOUNCE) and checking if you can carry them.
+// OF_ColorInvisItem			00800000 // Invisible item have a hue and GM can easily know they are invis.
 OptionFlags=08|080|0200
 
 // FeatureT2A, used to control T2A expansion features ( default 03 )

--- a/src/sphere.ini
+++ b/src/sphere.ini
@@ -685,7 +685,8 @@ AdvancedLos=0
 //ColorNotoInvulGameMaster=0b	// purple
 //ColorNotoDefault=03b2		// grey (if not any other)
 
-ColorInvis=0			// 04001 = transparent color, 0 = default (Including invis item see by GM)
+ColorInvisItem=1000		// 04001 = transparent color, 0 = default item color , 1000 = Grey color (Define how the invis item are see by GM)
+ColorInvis=0			// 04001 = transparent color, 0 = default
 ColorInvisSpell=0		// 04001 = transparent color, 0 = default (This one is for s_invisibility spell, this includes the invis potion.)
 ColorHidden=0			// 04001 = transparent color, 0 = default
 
@@ -764,7 +765,6 @@ Experimental=0
 // OF_StatAllowValOverMax		00100000 // Allow stats value above their maximum value (i.e. allow hits value > maxhits).
 // OF_GuardOutsideGuardedArea   00200000 // Allow guards to walk in unguarded areas, instead of being teleported back to their home point.
 // OF_OWNoDropCarriedItem		00400000 // When overweighted, don't drop items on ground when moving them (or using BOUNCE) and checking if you can carry them.
-// OF_ColorInvisItem			00800000 // Invisible item have a hue and GM can easily know they are invis.
 OptionFlags=08|080|0200
 
 // FeatureT2A, used to control T2A expansion features ( default 03 )

--- a/src/sphere.ini
+++ b/src/sphere.ini
@@ -685,7 +685,7 @@ AdvancedLos=0
 //ColorNotoInvulGameMaster=0b	// purple
 //ColorNotoDefault=03b2		// grey (if not any other)
 
-ColorInvisItem=1000		// 04001 = transparent color, 0 = default item color , 1000 = Grey color (Define how the invis item are see by GM)
+ColorInvisItem=1000		// 0 = default item color, 01 to 04001 = custom color, 1000 = invis Grey color (Define how the invis item are see by GM)
 ColorInvis=0			// 04001 = transparent color, 0 = default
 ColorInvisSpell=0		// 04001 = transparent color, 0 = default (This one is for s_invisibility spell, this includes the invis potion.)
 ColorHidden=0			// 04001 = transparent color, 0 = default


### PR DESCRIPTION
This pull request add a feature (#537 ) to be able to see invis item in grey.
![image](https://user-images.githubusercontent.com/51728381/100402329-f65cc780-3029-11eb-95a3-8b65ac875a8d.png)

Because it's a new feature, I added an ini setting. We can modify the color of item with an already existing setting.