### PR TITLE
Change the hue of invis Item just before send packet to client.

### DIFF
--- a/src/game/CObjBase.h
+++ b/src/game/CObjBase.h
@@ -568,7 +568,7 @@ public:
      *
      * @return  The hue.
      */
-	virtual HUE_TYPE GetHue() const;
+	HUE_TYPE GetHue() const;
 
 protected:
 

--- a/src/game/items/CItem.cpp
+++ b/src/game/items/CItem.cpp
@@ -1901,7 +1901,7 @@ bool CItem::SetName( lpctstr pszName )
 	return SetNamePool( pszName );
 }
 
-HUE_TYPE CItem::GetHue_visualforclient() const
+HUE_TYPE CItem::GetHueVisible() const
 {
 	if (g_Cfg.m_iColorInvisItem) //If setting ask a specific color
 	{

--- a/src/game/items/CItem.cpp
+++ b/src/game/items/CItem.cpp
@@ -1901,7 +1901,7 @@ bool CItem::SetName( lpctstr pszName )
 	return SetNamePool( pszName );
 }
 
-HUE_TYPE CItem::GetHue() const  //Override of CObjBase::GetHue()
+HUE_TYPE CItem::GetHue_visualforclient() const
 {
 	if (g_Cfg.m_iColorInvisItem) //If setting ask a specific color
 	{

--- a/src/game/items/CItem.h
+++ b/src/game/items/CItem.h
@@ -586,13 +586,13 @@ public:
     byte GetRangeH() const;
 
 	/**
-  * @fn  HUE_TYPE GetHue() const;
+  * @fn  HUE_TYPE GetHue_visualforclient() const;
   *
-  * @brief   Gets the hue.
+  * @brief   Gets the "fake" hue before sending the packet to client. The real hue of the item do not change.
   *
-  * @return  The hue.
+  * @return  The hue that the client will see the item.
   */
-	virtual HUE_TYPE GetHue() const override;
+	HUE_TYPE GetHue_visualforclient() const;
 
 	void SetAttr(uint64 uiAttr)
 	{

--- a/src/game/items/CItem.h
+++ b/src/game/items/CItem.h
@@ -586,13 +586,13 @@ public:
     byte GetRangeH() const;
 
 	/**
-  * @fn  HUE_TYPE GetHue_visualforclient() const;
+  * @fn  HUE_TYPE GetHueVisible () const;
   *
   * @brief   Gets the "fake" hue before sending the packet to client. The real hue of the item do not change.
   *
   * @return  The hue that the client will see the item.
   */
-	HUE_TYPE GetHue_visualforclient() const;
+	HUE_TYPE GetHueVisible() const;
 
 	void SetAttr(uint64 uiAttr)
 	{

--- a/src/network/send.cpp
+++ b/src/network/send.cpp
@@ -885,7 +885,7 @@ PacketItemContainer::PacketItemContainer(const CClient* target, const CItem* ite
 
 	const CItemBase* itemDefinition = item->Item_GetDef();
 	ITEMID_TYPE id = item->GetDispID();
-	HUE_TYPE hue = item->GetHue_visualforclient() & HUE_MASK_HI;
+	HUE_TYPE hue = item->GetHueVisible() & HUE_MASK_HI;
 
 	if (itemDefinition && target->GetResDisp() < itemDefinition->GetResLevel())
 	{
@@ -1228,7 +1228,7 @@ PacketItemContents::PacketItemContents(CClient* target, const CItemContainer* co
 
 		const CItemBase* itemDefinition = item->Item_GetDef();
 		ITEMID_TYPE id = item->GetDispID();
-		HUE_TYPE hue = item->GetHue_visualforclient() & HUE_MASK_HI;
+		HUE_TYPE hue = item->GetHueVisible() & HUE_MASK_HI;
 
 		if ( fFilterLayers )
 		{
@@ -5125,7 +5125,7 @@ PacketItemWorldNew::PacketItemWorldNew(const CClient* target, const CItem *item)
             amount = itemAmount;
     }
 	CPointMap pt = item->GetTopPoint();
-	HUE_TYPE hue = item->GetHue_visualforclient();
+	HUE_TYPE hue = item->GetHueVisible();
 	byte light = 0;
 	byte flags = 0;
 

--- a/src/network/send.cpp
+++ b/src/network/send.cpp
@@ -885,7 +885,7 @@ PacketItemContainer::PacketItemContainer(const CClient* target, const CItem* ite
 
 	const CItemBase* itemDefinition = item->Item_GetDef();
 	ITEMID_TYPE id = item->GetDispID();
-	HUE_TYPE hue = item->GetHue() & HUE_MASK_HI;
+	HUE_TYPE hue = item->GetHue_visualforclient() & HUE_MASK_HI;
 
 	if (itemDefinition && target->GetResDisp() < itemDefinition->GetResLevel())
 	{
@@ -1228,7 +1228,7 @@ PacketItemContents::PacketItemContents(CClient* target, const CItemContainer* co
 
 		const CItemBase* itemDefinition = item->Item_GetDef();
 		ITEMID_TYPE id = item->GetDispID();
-		HUE_TYPE hue = item->GetHue() & HUE_MASK_HI;
+		HUE_TYPE hue = item->GetHue_visualforclient() & HUE_MASK_HI;
 
 		if ( fFilterLayers )
 		{
@@ -5125,7 +5125,7 @@ PacketItemWorldNew::PacketItemWorldNew(const CClient* target, const CItem *item)
             amount = itemAmount;
     }
 	CPointMap pt = item->GetTopPoint();
-	HUE_TYPE hue = item->GetHue();
+	HUE_TYPE hue = item->GetHue_visualforclient();
 	byte light = 0;
 	byte flags = 0;
 


### PR DESCRIPTION
The setting ColorInvisItem change the Hue of invis item and permit the GM to make difference between invis item or not.

The last method had a bug and the global gethue fonction was use to change the color of item. It was causing some problem and sometime the real COLOR of the item was taking the "fake" hue.

With this commit you get the "fake" hue just before send the packet to the client.