### PR TITLE
Port From 56d pet release dialog

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2319,3 +2319,8 @@ Must have event, even if it's empty, since it's applied by the source to generat
 		change the gold you will receive when selling it to a NPC. PRICE is now exclusive to player vendor.
 - Added: tag.override.value can now be add to an item to change his value when trading with a NPC. In scripts, on vendor template 
 		(BUY= or SELL=). For changing the value of the itemdef, you must use tag.override.value=xxx instead of old syntax price=xxx.
+
+02-12-2020, Jhobean
+- [Ports from 0.56d, 12 Mar 2019 , Coruja]
+- Added: Pet command 'release' now will look for new 'd_pet_release' confirmation dialog.
+		Note: If dialog exists it will open the confirmation dialog, otherwise the pet will be released without ask for confirmation

--- a/src/game/chars/CChar.h
+++ b/src/game/chars/CChar.h
@@ -1259,6 +1259,7 @@ public:
 	void NPC_ExtraAI();			//	NPC thread AI - some general extra operations
 	void NPC_AddSpellsFromBook(CItem * pBook);
 
+	void NPC_PetRelease();
 	void NPC_PetDesert();
 	void NPC_PetClearOwners();
 	bool NPC_PetSetOwner( CChar * pChar );

--- a/src/game/chars/CCharNPCAct.cpp
+++ b/src/game/chars/CCharNPCAct.cpp
@@ -152,10 +152,8 @@ bool CChar::NPC_OnVerb( CScript &s, CTextConsole * pSrc ) // Execute command fro
 	case NV_PETSTABLE:
 		return( NPC_StablePetSelect( pCharSrc ));
 	case NV_RELEASE:
-		Skill_Start( SKILL_NONE );
-		NPC_PetClearOwners();
-		SoundChar( CRESND_RAND );
-		return true;
+		NPC_PetRelease();
+		break;
 	case NV_RESTOCK:	// individual restock command.
 		return NPC_Vendor_Restock(true, s.GetArgVal() != 0);
 	case NV_RUN:

--- a/src/game/chars/CCharNPCPet.cpp
+++ b/src/game/chars/CCharNPCPet.cpp
@@ -221,17 +221,10 @@ bool CChar::NPC_OnHearPetCmd( lpctstr pszCmd, CChar *pSrc, bool fAllPets )
 			break;
 
 		case PC_RELEASE:
-			if ( IsStatFlag(STATF_CONJURED) || (m_pNPC->m_bonded && IsStatFlag(STATF_DEAD)) )
-			{
-				Effect(EFFECT_XYZ, ITEMID_FX_TELE_VANISH, this, 10, 15);
-				Sound(SOUND_TELEPORT);
-				Delete();
-				return true;
-			}
-			SoundChar(CRESND_NOTICE);
-			Skill_Start(SKILL_NONE);
-			NPC_PetClearOwners();
-			UpdatePropertyFlag();
+			if (IsValidDef("d_pet_release"))
+				pSrc->m_pClient->Dialog_Setup(CLIMODE_DIALOG, g_Cfg.ResourceGetIDType(RES_DIALOG, "d_pet_release"), 0, this);
+			else
+				NPC_PetRelease();
 			break;
 
 		case PC_DROP:
@@ -852,6 +845,26 @@ bool CChar::NPC_SetVendorPrice( CItem * pItem, int iPrice )
 	return true;
 }
 
+void CChar::NPC_PetRelease()
+{
+	ADDTOCALLSTACK("CChar::NPC_PetRelease");
+	if (!m_pNPC)
+		return;
+
+	if (IsStatFlag(STATF_CONJURED) || (m_pNPC->m_bonded && IsStatFlag(STATF_DEAD)))
+	{
+		Effect(EFFECT_XYZ, ITEMID_FX_TELE_VANISH, this, 10, 15);
+		Sound(SOUND_TELEPORT);
+		Delete();
+		return;
+	}
+
+	SoundChar(CRESND_NOTICE);
+	Skill_Start(SKILL_NONE);
+	NPC_PetClearOwners();
+	UpdatePropertyFlag();
+}
+
 void CChar::NPC_PetDesert()
 {
 	ADDTOCALLSTACK("CChar::NPC_PetDesert");
@@ -872,7 +885,6 @@ void CChar::NPC_PetDesert()
 			return;
 	}
 
-	NPC_PetClearOwners();
 	if ( ! pCharOwn->CanSee(this))
 		pCharOwn->SysMessagef(g_Cfg.GetDefaultMsg(DEFMSG_NPC_PET_DESERTED), GetName());
 
@@ -881,5 +893,5 @@ void CChar::NPC_PetDesert()
 	Speak(pszMsg);
 
 	// free to do as i wish !
-	Skill_Start( SKILL_NONE );
+	NPC_PetRelease();
 }


### PR DESCRIPTION
I ported the 56d Dialog for the pet release.
![image](https://user-images.githubusercontent.com/51728381/100956708-0c193380-34e7-11eb-8901-43cedbbbf10d.png)

This dialog is there on OSI.