### PR TITLE
FIX the xcontrol to avoid they port far away (Issue #523)

### DIFF
--- a/src/game/clients/CClientTarg.cpp
+++ b/src/game/clients/CClientTarg.cpp
@@ -160,6 +160,11 @@ bool CClient::Cmd_Control( CChar * pChar2 )
 	ASSERT(m_pChar);
 	CChar * pChar1 = m_pChar;
 
+	//Switch their home position to avoid the pChar1 corpse teleport to his home(far away)
+	CPointMap homeP1 = pChar1->m_ptHome;
+	pChar1->m_ptHome.Set(pChar2->m_ptHome);
+	pChar2->m_ptHome.Set(homeP1);
+
 	// Put my newbie equipped items on it.
 	for (CSObjContRec* pObjRec : pChar1->GetIterationSafeContReverse())
 	{


### PR DESCRIPTION
Like explain on issue #523, when you take control of a NPC, your old corpse go back to his home position. This home is often far away and the corpse teleport.

On the processe of switching the corpse, I transfert the home position too.