### PR TITLE
Fix for NPCs stop attacking after being poisoned NPC (Issue #487) and Fixweight not working properly (Issue #502).

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2319,3 +2319,8 @@ Must have event, even if it's empty, since it's applied by the source to generat
 		change the gold you will receive when selling it to a NPC. PRICE is now exclusive to player vendor.
 - Added: tag.override.value can now be add to an item to change his value when trading with a NPC. In scripts, on vendor template 
 		(BUY= or SELL=). For changing the value of the itemdef, you must use tag.override.value=xxx instead of old syntax price=xxx.
+		
+		
+05-12-2020, Drk84
+-Fixed: NPCs stop attacking after being poisoned NPC  (Issue #487).
+-Fixed: Fixweight not working properly (Issue #502).

--- a/src/game/CContainer.cpp
+++ b/src/game/CContainer.cpp
@@ -99,7 +99,13 @@ int CContainer::FixWeight()
 	{
 		CItemContainer *pCont = dynamic_cast<CItemContainer *>(pObjRec);
 		if (!pCont)
+		{
+			//For every non-container item inside this container add its weight to it.
+			CItem* pItem = dynamic_cast<CItem*>(pObjRec);
+			if (pItem)
+				m_totalweight += pItem->GetWeight();
 			continue;
+		}
 
         pCont->FixWeight();
         if (!pCont->IsWeighed())	// bank box doesn't count for weight.

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -874,7 +874,7 @@ effect_bounce:
 			attacker.elapsed = 0;
 			attacker.amountDone = maximum( 0, iDmg );
 			attacker.threat = maximum( 0, iDmg );
-			//attacker.ignore = false;
+			attacker.ignore = false;
 			m_lastAttackers.emplace_back(std::move(attacker));
 		}
 

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -874,6 +874,7 @@ effect_bounce:
 			attacker.elapsed = 0;
 			attacker.amountDone = maximum( 0, iDmg );
 			attacker.threat = maximum( 0, iDmg );
+			//attacker.ignore = false;
 			m_lastAttackers.emplace_back(std::move(attacker));
 		}
 


### PR DESCRIPTION
 -Fixed: NPCs stop attacking after being poisoned NPC (Issue #487).


The bug happens when a NPC get damaged while the player is not reachable and it was caused by a missing assignement in the check in method CCharFight::OnTakeDamage

```
 if (bAttackerExists == false)
  {
   ....
   attacker.ignore = false; //Attacking.ignore was not set causing it to be set at 246
   m_lastAttackers.emplace_back(std::move(attacker));
  }
```


When the player goes away, the player is properly removed from the NPC's attacker list,  but if in the meantime the NPC suffers damage from the player by a command/item that
calls directly OnTakeDamage the NPC will add back the player but without setting the attacker.ignore property properly (It was set to 246 in my case).

-Fixed: Fixweight not working properly (Issue #502).

The problem was caused by the  method call:

```
 m_totalweight += pCont->GetWeight();
...
int CItemContainer::GetWeight(word amount) const
{ // true weight == container item + contents.
 return( CItem::GetWeight(amount) + CContainer::GetTotalWeight());
}
```

CContainer::GetTotalWeight would return m_totalweight of the current container but at the top of the Fixweight method we set m_totalweight value to 0 with the result
that Fixweight returned only the weight of the single item containers.

Minor problem i found:
When a player login, it seems that the Bank box weight it's added to is own weight, so a naked player should only weights 3 stones (backpack) but instead it weights 6 stones (3 backpack + 3 bank box)
I can't manage to track it.

@drk84
Forgot to remove the // 