### PR TITLE
[Port 56d] 3 Commits from 56d

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2320,7 +2320,11 @@ Must have event, even if it's empty, since it's applied by the source to generat
 - Added: tag.override.value can now be add to an item to change his value when trading with a NPC. In scripts, on vendor template 
 		(BUY= or SELL=). For changing the value of the itemdef, you must use tag.override.value=xxx instead of old syntax price=xxx.
 		
-		
 05-12-2020, Drk84
 -Fixed: NPCs stop attacking after being poisoned NPC  (Issue #487).
 -Fixed: Fixweight not working properly (Issue #502).
+
+11-12-2020, Jhobean
+- [Port from 0.56d, 01-08-2016, Coruja]
+	Fixed: Items inside trade window not firing @DropOn_Item trigger when the trade move the item to player bacpkack.
+	PS: Using return 1 here will not cancel the trade, this must be done directly on @TradeAccepted/@CharTradeAccepted triggers.

--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2328,3 +2328,4 @@ Must have event, even if it's empty, since it's applied by the source to generat
 - [Port from 0.56d, 01-08-2016, Coruja]
 	Fixed: Items inside trade window not firing @DropOn_Item trigger when the trade move the item to player bacpkack.
 	PS: Using return 1 here will not cancel the trade, this must be done directly on @TradeAccepted/@CharTradeAccepted triggers.
+- [Port from 0.56d, 12-11-2016, Coruja] Fixed: Resurrect, showing effect animation even when EFFECT_ID=0 is set

--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -1896,6 +1896,15 @@ bool CChar::ItemBounce( CItem * pItem, bool fDisplayMsg )
 	if (pPack && CanCarry(pItem) && pPack->CanContainerHold(pItem, this))		// this can happen at load time
 	{
 		fCanAddToPack = true;
+		if (IsTrigUsed(TRIGGER_DROPON_ITEM))
+		{
+			CScriptTriggerArgs Args(pPack);
+			pItem->OnTrigger(ITRIG_DROPON_ITEM, this, &Args);
+
+			if (pItem->IsDeleted())	// the trigger had deleted the item
+				return false;
+		}
+
 		if (IsTrigUsed(TRIGGER_DROPON_SELF) || IsTrigUsed(TRIGGER_ITEMDROPON_SELF))
 		{
             const CItem* pPrevCont = dynamic_cast<CItem*>(pItem->GetContainer());

--- a/src/game/chars/CCharSpell.cpp
+++ b/src/game/chars/CCharSpell.cpp
@@ -3672,6 +3672,8 @@ bool CChar::OnSpellEffect( SPELL_TYPE spell, CChar * pCharSrc, int iSkillLevel, 
 			return Spell_Resurrection(nullptr, pCharSrc, (pSourceItem && pSourceItem->IsType(IT_SHRINE)));
 
 		case SPELL_Light:
+			if (iEffectID)
+				Effect(EFFECT_OBJ, iEffectID, this, 9, 6, fExplode, iColor, dwRender);
 			Spell_Effect_Create( spell, LAYER_FLAG_Potion, iEffect, iDuration, pCharSrc );
 			break;
 

--- a/src/game/chars/CCharSpell.cpp
+++ b/src/game/chars/CCharSpell.cpp
@@ -19,7 +19,7 @@ SPELL_TYPE CChar::Spell_GetIndex(SKILL_TYPE skill)	// Returns the first spell fo
 
 	if (!g_Cfg.IsSkillFlag(skill, SKF_MAGIC))
 		return SPELL_NONE;
-
+	 
 	switch (skill)
 	{
 		case SKILL_MAGERY:
@@ -492,7 +492,8 @@ bool CChar::Spell_Resurrection(CItemCorpse * pCorpse, CChar * pCharSrc, bool fNo
 	}
 
 	CSpellDef *pSpellDef = g_Cfg.GetSpellDef(SPELL_Resurrection);
-	Effect(EFFECT_OBJ, pSpellDef->m_idEffect, this, 10, 16);
+	if (pSpellDef->m_idEffect)
+		Effect(EFFECT_OBJ, pSpellDef->m_idEffect, this, 10, 16);
 	Sound(pSpellDef->m_sound);
     if (IsClientActive())
     {
@@ -3616,7 +3617,7 @@ bool CChar::OnSpellEffect( SPELL_TYPE spell, CChar * pCharSrc, int iSkillLevel, 
 		case SPELL_Reveal:
 			if ( !Reveal() )
             {
-                iEffectID = ITEMID_NOTHING;
+				iEffectID = ITEMID_NOTHING;
                 iSound = SOUND_NONE;
             }
 			break;

--- a/src/game/chars/CCharSpell.cpp
+++ b/src/game/chars/CCharSpell.cpp
@@ -19,7 +19,7 @@ SPELL_TYPE CChar::Spell_GetIndex(SKILL_TYPE skill)	// Returns the first spell fo
 
 	if (!g_Cfg.IsSkillFlag(skill, SKF_MAGIC))
 		return SPELL_NONE;
-	 
+
 	switch (skill)
 	{
 		case SKILL_MAGERY:

--- a/src/game/clients/CChat.cpp
+++ b/src/game/clients/CChat.cpp
@@ -574,8 +574,6 @@ void CChat::GenerateChatName(CSString &sName, const CClient * pClient) // static
 	lpctstr pszName = nullptr;
 	if (pClient->GetChar() != nullptr)
 		pszName = pClient->GetChar()->GetName();
-	else if (pClient->GetAccount() != nullptr)
-		pszName = pClient->GetAccount()->GetName();
 
 	if (pszName == nullptr)
 		return;


### PR DESCRIPTION

**SphereX Issue #59**
Fixed: Items inside trade window not firing @DropOn_Item trigger
I tested and the issue was there. The fix by Coruja is now well apply on X.


**SphereX Issue #68** 
12-11-2016, Coruja
Fixed: Resurrect, Reveal, Meteor Swarm and Lightning spells showing effect animation even when EFFECT_ID=0 is set

Resurrect: Fixed like 56d
Reveal: Work differently on X no need of this
Light: Added the effect because it was wiped on X
Meteor Swarm :  On X it seem to be removed

**SphereX Issue #58** 
22-07-2016, Coruja
Fixed: Security issue setting account login as chat name when newest clients try to setup the chat window for the first time and the char name is not available.

I only removed the possibility to have account name as chat name. Description for the Fix was insane

