### PR TITLE
In older client, client version is sent to late after characterslection.

### DIFF
--- a/src/game/clients/CClientLog.cpp
+++ b/src/game/clients/CClientLog.cpp
@@ -879,8 +879,12 @@ bool CClient::xProcessClientSetup( CEvent * pEvent, uint uiLen )
 				CAccount * pAcc = g_Accounts.Account_Find( szAccount );
 				if (pAcc)
 				{
-					pAcc->m_TagDefs.SetNum("clientversion", m_Crypt.GetClientVer());
-					pAcc->m_TagDefs.SetNum("reportedcliver", GetNetState()->getReportedVersion());
+                    if (m_Crypt.GetClientVer())
+                        pAcc->m_TagDefs.SetNum("clientversion", m_Crypt.GetClientVer());
+					if (GetNetState()->getReportedVersion())
+                        pAcc->m_TagDefs.SetNum("reportedcliver", GetNetState()->getReportedVersion());
+                    else
+                        new PacketClientVersionReq(this); // client version 0 ? ask for it.
 				}
 				else
 				{

--- a/src/network/receive.cpp
+++ b/src/network/receive.cpp
@@ -2475,6 +2475,9 @@ bool PacketClientVersion::onReceive(CNetState* net)
 
 		if ((g_Serv.m_ClientVersion.GetClientVer() != 0) && (g_Serv.m_ClientVersion.GetClientVer() != version))
 			client->addLoginErr(PacketLoginError::BadVersion);
+        //we have asked client version in serverlist to configure character list and game feature.
+        if ( client->m_pAccount )
+                    client->m_pAccount->m_TagDefs.SetNum("ReportedCliVer", version);
 	}
 
 	return true;


### PR DESCRIPTION
to fix this issue #359  we send a ClientVersionReq after server list the we can setup the charlist and client features flags properly.

56D code:
https://github.com/Sphereserver/Source/blob/3d3c141fed72bb09bbdc4a1369fc0a410962ff15/src/graysvr/CClientLog.cpp#L649-L654
https://github.com/Sphereserver/Source/blob/191a13e7bc91a709db79d1270c467a5561038541/src/network/receive.cpp#L2653-L2655