### PR TITLE
Fixed field spells don't trigger onSpellEffect

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2353,3 +2353,4 @@ Must have event, even if it's empty, since it's applied by the source to generat
 
 22-12-2020, xwerswoodx
 Fixed: Mysql null pointer return causes server debug. (Issue: #544)
+Fixed: Field spells doesn't trigger onSpellEffect when they casted on player (Issue: #526)

--- a/src/common/version/GitRevision.h
+++ b/src/common/version/GitRevision.h
@@ -1,2 +1,2 @@
-#define __GITHASH__ "1b23b062484f0c63ed27e647872e5534fe7aacec"
+#define __GITHASH__ "bcc0a4c67ee218f62322ce088f5ac281da37a29d"
 #define __GITREVISION__ 3353

--- a/src/game/chars/CCharSpell.cpp
+++ b/src/game/chars/CCharSpell.cpp
@@ -2121,6 +2121,7 @@ void CChar::Spell_Field(CPointMap pntTarg, ITEMID_TYPE idEW, ITEMID_TYPE idNS, u
 
 				if (( idEW == ITEMID_STONE_WALL ) || ( idEW == ITEMID_FX_ENERGY_F_EW ) || ( idEW == ITEMID_FX_ENERGY_F_NS ))	// don't place stone wall over characters
 				{
+				    pChar->OnSpellEffect(m_atMagery.m_iSpell, this, iSkillLevel, nullptr);
 					fGoodLoc = false;
 					break;
 				}


### PR DESCRIPTION
Fields should trigger onSpellEffect when they casted on player, so i added onSpellEffect cast when the wall casted on player but removed. (Issue: #526)