### PR TITLE
Added ATTR_CANUSE_PARALYZED flag

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2352,5 +2352,14 @@ Must have event, even if it's empty, since it's applied by the source to generat
 - Added: ONAME property. An useful use case could be for item identification or polymorph scripts.
 
 22-12-2020, xwerswoodx
-Fixed: Mysql null pointer return causes server debug. (Issue: #544)
-Fixed: Field spells doesn't trigger onSpellEffect when they casted on player (Issue: #526)
+-Fixed: Mysql null pointer return causes server debug. (Issue: #544)
+-Fixed: Field spells doesn't trigger onSpellEffect when they casted on player (Issue: #526)
+	As Wall of Stone and Energy Field triggered onSpellEffect from now on, you have to add
+	spellflag_nounparalyze to your Wall of Stone and Energy Field spell flags.
+-Fixed: Players can't reach their backpacks.
+	I noted this as fix because in OSI default you can do this.
+-Added: ATTR_CANUSE_PARALYZED flag that allow people to use items while paralyzed status.
+	Value: 010000000.
+	This flag only gives a permission to Double Clicking items, this does mean, you can't be
+	allowed to equip items or using skills (like drum, flute...) or spells (like wands, scrolls).
+	But you can use scripting to equip/unequip items under dclick. (Like src.findlayer.layer_hand1.cont = <src>)

--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2359,7 +2359,7 @@ Must have event, even if it's empty, since it's applied by the source to generat
 -Fixed: Players can't reach their backpacks.
 	I noted this as fix because in OSI default you can do this.
 -Added: ATTR_CANUSE_PARALYZED flag that allow people to use items while paralyzed status.
-	Value: 010000000.
+	Value: 080000000.
 	This flag only gives a permission to Double Clicking items, this does mean, you can't be
 	allowed to equip items or using skills (like drum, flute...) or spells (like wands, scrolls).
 	But you can use scripting to equip/unequip items under dclick. (Like src.findlayer.layer_hand1.cont = <src>)

--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2353,3 +2353,4 @@ Must have event, even if it's empty, since it's applied by the source to generat
 
 22-12-2020, xwerswoodx
 Fixed: Mysql null pointer return causes server debug. (Issue: #544)
+Fixed: Field spells doesn't trigger onSpellEffect when they casted on player (Issue: #526)

--- a/src/common/version/GitRevision.h
+++ b/src/common/version/GitRevision.h
@@ -1,2 +1,2 @@
-#define __GITHASH__ "1b23b062484f0c63ed27e647872e5534fe7aacec"
+#define __GITHASH__ "bcc0a4c67ee218f62322ce088f5ac281da37a29d"
 #define __GITREVISION__ 3353

--- a/src/common/version/GitRevision.h
+++ b/src/common/version/GitRevision.h
@@ -1,2 +1,2 @@
-#define __GITHASH__ "bcc0a4c67ee218f62322ce088f5ac281da37a29d"
-#define __GITREVISION__ 3353
+#define __GITHASH__ "06f3ec554ef01eb3db0bcd45a2da7cd108bfc8a1"
+#define __GITREVISION__ 3354

--- a/src/game/chars/CCharSpell.cpp
+++ b/src/game/chars/CCharSpell.cpp
@@ -2121,6 +2121,7 @@ void CChar::Spell_Field(CPointMap pntTarg, ITEMID_TYPE idEW, ITEMID_TYPE idNS, u
 
 				if (( idEW == ITEMID_STONE_WALL ) || ( idEW == ITEMID_FX_ENERGY_F_EW ) || ( idEW == ITEMID_FX_ENERGY_F_NS ))	// don't place stone wall over characters
 				{
+				    pChar->OnSpellEffect(m_atMagery.m_iSpell, this, iSkillLevel, nullptr);
 					fGoodLoc = false;
 					break;
 				}

--- a/src/game/chars/CCharStatus.cpp
+++ b/src/game/chars/CCharStatus.cpp
@@ -1299,6 +1299,7 @@ bool CChar::CanTouch( const CObjBase *pObj ) const
 	{
         pItem = static_cast<const CItem *>(pObj);
 		bool fDeathImmune = IsPriv(PRIV_GM);
+		bool fFreezeImmune = false;
 		switch ( pItem->GetType() )
 		{
 		case IT_SIGN_GUMP:	// can be seen from a distance.
@@ -1308,6 +1309,12 @@ bool CChar::CanTouch( const CObjBase *pObj ) const
 		case IT_TELESCOPE:
             fDeathImmune = true;
 			break;
+        case IT_CONTAINER:
+        case IT_CONTAINER_LOCKED:
+        {
+            if ( pObjTop && pObjTop == this ) //This is default OSI behaviour, you can look through your backpack while frozen.
+                fFreezeImmune = true;
+        }
 
         case IT_ARCHERY_BUTTE:
         {
@@ -1331,8 +1338,14 @@ bool CChar::CanTouch( const CObjBase *pObj ) const
 		default:
 			break;
 		}
+        
+        if ( !fDeathImmune && IsStatFlag(STATF_FREEZE) )
+        {
+            if ( !fFreezeImmune && !pItem->IsAttr(ATTR_CANUSE_PARALYZED) )
+                return false;
+        }
 
-		if ( !fDeathImmune && IsStatFlag(STATF_DEAD|STATF_SLEEPING|STATF_FREEZE|STATF_STONE) )
+		if ( !fDeathImmune && IsStatFlag(STATF_DEAD|STATF_SLEEPING|STATF_STONE) )
 			return false;
 	}
 

--- a/src/game/items/CItem.h
+++ b/src/game/items/CItem.h
@@ -94,15 +94,15 @@ public:
 #define ATTR_SECURE				0x2000000			// Is Secure
 #define ATTR_REFORGED			0x4000000			// Is Runic Reforged.
 #define ATTR_OPENED				0x8000000			// Is Door Opened.
-#define ATTR_CANUSE_PARALYZED   0x10000000          // Can able to be used while paralyzed.
+#define ATTR_SHARDBOUND			0x10000000
+#define ATTR_ACCOUNTBOUND  		0x20000000
+#define ATTR_CHARACTERBOUND		0x40000000
+#define ATTR_CANUSE_PARALYZED   0x80000000          // Can able to be used while paralyzed.
 
 // TODO
 #define ATTR_CANNOTREPAIR		0x400000000000		// No repair, no fortify
 #define ATTR_FACTIONITEM		0x80000000000000	// ? Faction Item (Has cliloc)
 #define ATTR_VVVITEM			0x100000000000000	// ? Vice vs Virtue Item (Has CliLoc)
-#define ATTR_SHARDBOUND			0x200000000000000
-#define ATTR_ACCOUNTBOUND  		0x400000000000000
-#define ATTR_CHARACTERBOUND		0x800000000000000
 
 
 	uint64	m_Attr;

--- a/src/game/items/CItem.h
+++ b/src/game/items/CItem.h
@@ -94,14 +94,16 @@ public:
 #define ATTR_SECURE				0x2000000			// Is Secure
 #define ATTR_REFORGED			0x4000000			// Is Runic Reforged.
 #define ATTR_OPENED				0x8000000			// Is Door Opened.
-#define ATTR_SHARDBOUND			0x10000000
-#define ATTR_ACCOUNTBOUND  		0x20000000
-#define ATTR_CHARACTERBOUND		0x40000000
+#define ATTR_CANUSE_PARALYZED   0x10000000          // Can able to be used while paralyzed.
 
 // TODO
 #define ATTR_CANNOTREPAIR		0x400000000000		// No repair, no fortify
 #define ATTR_FACTIONITEM		0x80000000000000	// ? Faction Item (Has cliloc)
 #define ATTR_VVVITEM			0x100000000000000	// ? Vice vs Virtue Item (Has CliLoc)
+#define ATTR_SHARDBOUND			0x200000000000000
+#define ATTR_ACCOUNTBOUND  		0x400000000000000
+#define ATTR_CHARACTERBOUND		0x800000000000000
+
 
 	uint64	m_Attr;
 


### PR DESCRIPTION
This flag let people to use items while paralyzed, but still not allow to equip/unequip or moving items, also spell (scroll, wands) or skill (drum, flute) items not allowed to use. This is done to let people to choose some items that can use while paralyzed, like trapped pouch, or some similar type items.

Also while doing this, I added containers inside players' own backpack as exceptional for frozen at all, because in OSI you can do this, so this is default behaviour.