### PR TITLE
-Fixed: REGEN values not saved (issue #595).

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2458,3 +2458,9 @@ Reworked and improved Fastwalk (speedhack) dectection. It can be fine tuned with
 Depending of the latency of the server, there's the possibility to have false positive speedhack detection on the console. Walkregen ini setting should be raised until you don't have false positives.
 You can disable this detection for everyone by setting WalkBuffer=0. At all time, the detection is not active on GM player.
 Fastwalk detection will trigger @UserExWalkLimit. Like before you can avoid a rejected step with RETURN 1.
+
+28-02-2021, Drk84
+-Fixed: REGEN values not saved (issue #595).
+	RegenHits, RegenMana, RegenStam and RegenFood will now be saved only if their value is equal or above to 1 and different from the default value in the ini setting.
+	Default values in the ini are: 40 seconds for RegenHits, 20 seconds for RegenMana, 10 seconds for RegenStam and 86400 seconds (one day) for RegenFood.
+	

--- a/src/game/chars/CChar.cpp
+++ b/src/game/chars/CChar.cpp
@@ -3819,6 +3819,19 @@ void CChar::r_Write( CScript & s )
         s.WriteKeyVal("MAXMANA", iVal);     // should be OMAXMANA, but we keep it like this for backwards compatibility
     s.WriteKeyVal("MANA", Stat_GetVal(STAT_INT));
 
+	static constexpr lpctstr _ptcKeyRegen[STAT_QTY] =
+	{
+		"REGENHITS",
+		"REGENMANA",
+		"REGENSTAM",
+		"REGENFOOD"
+	};
+	for (ushort j = 0; j < STAT_QTY; ++j)
+	{
+		const int uiRegen = Stats_GetRegenRate((STAT_TYPE)j); //we cannot use ushort here because by default REGENFOOD has a value higher than 65k.
+		if (uiRegen > 1 && uiRegen != g_Cfg.m_iRegenRate[j])
+			s.WriteKeyVal(_ptcKeyRegen[j], uiRegen / MSECS_PER_SEC);
+	}
     static constexpr lpctstr _ptcKeyRegenVal[STAT_QTY] =
     {
         "REGENVALHITS",


### PR DESCRIPTION
 RegenHits, RegenMana, RegenStam and RegenFood will now be saved only if their value is equal or above to 1 and different from the default value in the ini setting.
 Default values in the ini are: 40 seconds for RegenHits, 20 seconds for RegenMana, 10 seconds for RegenStam and 86400 seconds (one day) for RegenFood.

I used int instead of ushort because the RegenFood value has a default value of 86400 above the maximum value of ushort.