### PR TITLE
Fix for Trading layer item was added to the character weight Issue #660 and  MonsterFear in Sphere.ini does not seem to affect monsters Issue #603

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2589,4 +2589,10 @@ Must have event, even if it's empty, since it's applied by the source to generat
 		Return 0: remove the spell memory item but don't execute the default spell behaviour when the spell item is removed.
 		
 		
-		
+20-04-2021, Drk84
+Fixed: Trading layer item was added to the character weight when starting a trade (Issue #660).
+Fixed: MonsterFear in Sphere.ini does not seem to affect monsters (Issue #603).
+	   I also changed a little the motivation formula, now the remaining health of the NPC counts more towards the fleeing chance.
+	   Take in consideration that if the NPC has a big STR value it will be unlikely to flee.
+	   Remember that you can modify ARGN2 in @NpcActFight trigger to set the motivation value (ARGN2 <= 0 the NPC will flee).
+	   

--- a/src/game/CContainer.cpp
+++ b/src/game/CContainer.cpp
@@ -149,7 +149,8 @@ void CContainer::ContentAddPrivate( CItem *pItem )
 	CSObjCont::InsertContentTail( pItem );
 	//pItem->RemoveUIDFlags(UID_O_DISCONNECT);
 
-	OnWeightChange(pItem->GetWeight());
+	if ( !pItem->IsType(IT_EQ_TRADE_WINDOW) )  //Don't apply trade window layer item weight on character weight.
+		OnWeightChange(pItem->GetWeight());
 
 	if (auto pThisObj = dynamic_cast<const CObjBase*>(this))
 	{
@@ -195,7 +196,8 @@ void CContainer::OnRemoveObj( CSObjContRec *pObRec )	// Override this = called w
 	ASSERT(pItem->GetParent() == nullptr);
 
 	pItem->SetUIDContainerFlags(UID_O_DISCONNECT);		// It is no place for the moment.
-	OnWeightChange(-pItem->GetWeight());
+	if ( !pItem->IsType(IT_EQ_TRADE_WINDOW) ) //Don't apply trade window layer item weight on character weight.
+		OnWeightChange(-pItem->GetWeight());
 }
 
 void CContainer::r_WriteContent( CScript &s ) const

--- a/src/game/chars/CCharNPCAct.cpp
+++ b/src/game/chars/CCharNPCAct.cpp
@@ -1264,7 +1264,16 @@ bool CChar::NPC_Act_Follow(bool fFlee, int maxDistance, bool fMoveAway)
 		return false;
 
 	EXC_TRY("NPC_Act_Follow");
-	CChar * pChar = Fight_IsActive() ? m_Fight_Targ_UID.CharFind() : m_Act_UID.CharFind();
+
+	/*
+	* Replaced the Fight_IsActive() check with a check on m_fight_targ_UID.
+	* Red npcs usually never interact "in a peaceful way" with the players and thus m_act_UID is usually never set preventing the creature from fleeing and putting it in an immobile "state".
+	* Fight_IsActive returns true if the character is actively fighting (using a combat skill) in this case it's false because of the NPC'sFleeing
+	* Action and thus it will never pass the Fight_IsActive() check
+	*/
+	//CChar * pChar =  Fight_IsActive() ? m_Fight_Targ_UID.CharFind() : m_Act_UID.CharFind();
+	CChar * pChar =  m_Fight_Targ_UID ? m_Fight_Targ_UID.CharFind() : m_Act_UID.CharFind();
+
 	if (pChar == nullptr)
 	{
 		// free to do as i wish !

--- a/src/game/chars/CCharNPCStatus.cpp
+++ b/src/game/chars/CCharNPCStatus.cpp
@@ -876,11 +876,7 @@ int CChar::NPC_GetAttackContinueMotivation( CChar * pChar, int iMotivation ) con
 	iMotivation += ( Stat_GetAdjusted(STAT_STR) - pChar->Stat_GetAdjusted(STAT_STR));
 
 	// I'm healthy.
-	int iTmp = GetHealthPercent() - pChar->GetHealthPercent();
-	if ( iTmp < -50 )
-		iMotivation -= 50;
-	else if ( iTmp > 50 )
-		iMotivation += 50;
+	iMotivation += GetHealthPercent() - pChar->GetHealthPercent();
 
 	// I'm smart and therefore more cowardly. (if injured)
 	iMotivation -= Stat_GetAdjusted(STAT_INT) / 16;

--- a/src/game/chars/CCharSpell.cpp
+++ b/src/game/chars/CCharSpell.cpp
@@ -551,7 +551,7 @@ void CChar::Spell_Effect_Remove(CItem * pSpell)
 		Args.m_pO1 = pSpell;
 		Args.m_iN1 = spell;
 		TRIGRET_TYPE iRet = Spell_OnTrigger(spell, SPTRIG_EFFECTREMOVE, pCaster, &Args);
-		if (iRet == TRIGRET_RET_FALSE)		// return 0: we want the memory to be equipped but we want custom things to happen: don't remove memory but stop here,
+		if (iRet == TRIGRET_RET_FALSE)		// Return 0: remove the spell memory item but don't execute the default spell behaviour.
 			return;
 	}
 


### PR DESCRIPTION
Fixed: Trading layer item was added to the character weight when starting a trade (Issue #660).
The problem was caused because when the trade window item was created, its weight was added to the character.

Fixed: MonsterFear in Sphere.ini does not seem to affect monsters (Issue #603).
Hostile (red) NPCs usually does not interact with players and so their act value is not usually set.
The previous check used the Fight_IsActive method but because the hostile NPC already started the "Fleeing action" the check always returned false and in this case the NPC would attempt to flee from the player whose UID is stored in act, which usually for hostile NPCs is often empty. The result was the NPC standing idle and doing nothing.
The check is now made on the NPC attacker.target property (m_Fight_Targ_UID).