### PR TITLE
Fixed: The NEW object after executing the NEWDUPE command always retu…

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2588,7 +2588,6 @@ Must have event, even if it's empty, since it's applied by the source to generat
 		Argn1: the spell number.
 		Return 0: remove the spell memory item but don't execute the default spell behaviour when the spell item is removed.
 		
-		
 20-04-2021, Drk84
 Fixed: Trading layer item was added to the character weight when starting a trade (Issue #660).
 Fixed: MonsterFear in Sphere.ini does not seem to affect monsters (Issue #603).
@@ -2596,3 +2595,5 @@ Fixed: MonsterFear in Sphere.ini does not seem to affect monsters (Issue #603).
 	   Take in consideration that if the NPC has a big STR value it will be unlikely to flee.
 	   Remember that you can modify ARGN2 in @NpcActFight trigger to set the motivation value (ARGN2 <= 0 the NPC will flee).
 	   
+22/04/2021, Drk84
+Fixed: The NEW object after executing the NEWDUPE command always returned the last created item instead of the newly duped character (Issue #661).

--- a/src/game/chars/CChar.cpp
+++ b/src/game/chars/CChar.cpp
@@ -1215,7 +1215,8 @@ bool CChar::DupeFrom(const CChar * pChar, bool fNewbieItems )
 	{
 		_GoAwake();
 	}
-
+	//g_World.m_uidNew stored the last duped item, so we need to set back again the newly duped character.
+	g_World.m_uidNew.SetObjUID(GetUID());
 	Update();
 	return true;
 }


### PR DESCRIPTION
…rned the last created item instead of the newly duped character (Issue #661).

The g_World.m_uidNew stored the last duped item from the dupe character process, so we need to set back again the UID of the newly duped character.