### PR TITLE
Fix for: Crash on failed spell(Issue #666) and Duped tamed creatures do not increase followerslots (Issue #663).

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2589,11 +2589,15 @@ Must have event, even if it's empty, since it's applied by the source to generat
 		Return 0: remove the spell memory item but don't execute the default spell behaviour when the spell item is removed.
 		
 20-04-2021, Drk84
-Fixed: Trading layer item was added to the character weight when starting a trade (Issue #660).
-Fixed: MonsterFear in Sphere.ini does not seem to affect monsters (Issue #603).
+- Fixed: Trading layer item was added to the character weight when starting a trade (Issue #660).
+- Fixed: MonsterFear in Sphere.ini does not seem to affect monsters (Issue #603).
 	   I also changed a little the motivation formula, now the remaining health of the NPC counts more towards the fleeing chance.
 	   Take in consideration that if the NPC has a big STR value it will be unlikely to flee.
 	   Remember that you can modify ARGN2 in @NpcActFight trigger to set the motivation value (ARGN2 <= 0 the NPC will flee).
 	   
-22/04/2021, Drk84
-Fixed: The NEW object after executing the NEWDUPE command always returned the last created item instead of the newly duped character (Issue #661).
+22-04-2021, Drk84
+- Fixed: The NEW object after executing the NEWDUPE command always returned the last created item instead of the newly duped character (Issue #661).
+
+23-04-2021, Drk84
+- Fixed: Crash on failed spell.(Issue #666).
+- Fixed: Duped tamed creatures do not increase followerslots (Issue #663).

--- a/src/game/chars/CChar.cpp
+++ b/src/game/chars/CChar.cpp
@@ -1203,9 +1203,19 @@ bool CChar::DupeFrom(const CChar * pChar, bool fNewbieItems )
 			}
 		}
 
-		const CChar * pTest3 = CUID::CharFindFromUID(pItem->m_uidLink);
-		if ( pTest3 && pTest3 == pChar)
-			pItem->m_uidLink = myUID;
+		CChar * pTest3 = CUID::CharFindFromUID(pItem->m_uidLink);
+		if (pTest3)
+		{
+			if (pTest3 == pChar)
+				pItem->m_uidLink = myUID; //If the character being duped has an item which linked to himself, set the newly duped character link instead.
+			else if (IsSetOF(OF_PetSlots) &&  pItem->IsMemoryTypes(MEMORY_IPET) && pTest3 == NPC_PetGetOwner())
+			{
+				const short iFollowerSlots = (short)GetDefNum("FOLLOWERSLOTS", true, 1);
+				//If we have reached the maximum follower slots we remove the ownership of the pet by clearing the memory flag instead of using NPC_PetClearOwners().
+				if (!pTest3->FollowersUpdate(this, maximum(0, iFollowerSlots)))
+					Memory_ClearTypes(MEMORY_IPET); 
+			}
+		}
 	}
 	// End copying items.
 

--- a/src/game/chars/CCharSpell.cpp
+++ b/src/game/chars/CCharSpell.cpp
@@ -3149,6 +3149,9 @@ void CChar::Spell_CastFail(bool fAbort)
 
 	ushort iManaLoss = 0, iTithingLoss = 0;
 	CSpellDef *pSpell = g_Cfg.GetSpellDef(m_atMagery.m_iSpell);
+ 	if (!pSpell)
+		return;
+
 	if (g_Cfg.m_fManaLossFail && !fAbort)
 		iManaLoss = g_Cfg.Calc_SpellManaCost(this, pSpell, m_Act_Prv_UID.ObjFind());
 


### PR DESCRIPTION
Crash on failed spell (Issue #666).
Missin check on method Spell_CastFail caused Sphere to crash if the spell was not valid. (I still don't know why they get an invalid spell in first place when the target dies, it seems to happens casually).

Duped tamed creatures do not increase followerslots (Issue #663):
The followerslots update was not implemented.