### PR TITLE
Players pets getting stuck when giving follow order while in combat (Issue #681).

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2695,3 +2695,6 @@ Must have event, even if it's empty, since it's applied by the source to generat
 08-05-2021, Nolok
 - Fixed: Item timer set on @Create being reset when the item is equipped on a char immediately after (Issue #662).
 - Fixed: Exception generated upon server closure, if a char existed with an attached MultiStorage.
+
+15-05-2021, Drk84
+- Fixed: Player's pet getting stuck when giving follow order while in combat (Issue #681).

--- a/src/game/chars/CCharNPCAct.cpp
+++ b/src/game/chars/CCharNPCAct.cpp
@@ -1272,8 +1272,13 @@ bool CChar::NPC_Act_Follow(bool fFlee, int maxDistance, bool fMoveAway)
 	* Action and thus it will never pass the Fight_IsActive() check
 	*/
 	//CChar * pChar =  Fight_IsActive() ? m_Fight_Targ_UID.CharFind() : m_Act_UID.CharFind();
-	CChar * pChar =  m_Fight_Targ_UID.IsValidUID() ? m_Fight_Targ_UID.CharFind() : m_Act_UID.CharFind();
 
+	CChar* pChar = nullptr;
+	//If the NPC action is following somebody, directly assign the character from  the m_Act_UID value. 
+	if (Skill_GetActive() == NPCACT_FOLLOW_TARG)
+		pChar = m_Act_UID.CharFind();
+	else
+		pChar = m_Fight_Targ_UID.IsValidUID() ? m_Fight_Targ_UID.CharFind() : m_Act_UID.CharFind();
 	if (pChar == nullptr)
 	{
 		// free to do as i wish !

--- a/src/game/components/CCPropsItemEquippable.cpp
+++ b/src/game/components/CCPropsItemEquippable.cpp
@@ -262,10 +262,10 @@ void CCPropsItemEquippable::AddPropsTooltipData(CObjBase* pLinkedObj)
             case PROPIEQUIP_CASTINGFOCUS: // unimplemented
                 ADDTNUM(1113696);
                 break;
-            case PROPIEQUIP_COMBATBONUSPERCENT: // unimplemented -> it should raise char's prop
+            case PROPIEQUIP_COMBATBONUSPERCENT: // Implemented the 15/03/2015 by Xun (Sphere 56c), it determines the % of the stat used for bonus combat damage.
                 //Missing cliloc id
                 break;
-            case PROPIEQUIP_COMBATBONUSSTAT: // unimplemented (what should this do?)
+            case PROPIEQUIP_COMBATBONUSSTAT: // Implemented the 15/03/2015 by Xun (Sphere 56c), it determines what stat (Str, Dex, or Int) is used for bonus combat damage.
                 //Missing cliloc id
                 break;
             case PROPIEQUIP_DAMCHAOS: // unimplemented


### PR DESCRIPTION
The bug was caused by a mine previous commit on the following line in the CCharNpcAct.cpp file in the NPC_Act_Follow method:

`pChar = m_Fight_Targ_UID.IsValidUID() ? m_Fight_Targ_UID.CharFind() : m_Act_UID.CharFind();`

When a player pet received the follow order while in combat, the character from  m_fight_Targ_UID  was always chosen instead of the one from m_Act_UID, for fixing this i added this explict check on the character current action
`//If the NPC action is following somebody, directly assign the character from  the m_Act_UID value. 
	if (Skill_GetActive() == NPCACT_FOLLOW_TARG)
		pChar = m_Act_UID.CharFind();
	else
		pChar = m_Fight_Targ_UID.IsValidUID() ? m_Fight_Targ_UID.CharFind() : m_Act_UID.CharFind();`