### PR TITLE
Added: TAG.NAME.HUE for items. This works only if tooltips are disabled and some fixes.

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2698,3 +2698,11 @@ Must have event, even if it's empty, since it's applied by the source to generat
 
 15-05-2021, Drk84
 - Fixed: Player's pet getting stuck when giving follow order while in combat (Issue #681).
+
+20-05-2021, Drk84
+- Added: TAG.NAME.HUE for items. This works only if tooltips are disabled (FEATURE_AOS_UPDATE_B not set).
+- Fixed: Crash when accessing  a non-existant SRC (the caster) in the @EffectRemove and @EffectTick triggers.
+		 Remember to use the ISVALID command by assigning SRC to a REF to check if the caster is still valid
+- Fixed: Necromancy spells Blood Oath and Evil Omen have their default behaviour executed even if their spell definition has the SPELLFLAG_SCRIPTED set.
+- Fixed: Poison memory item  was not re-created after a character was poisoned again. 
+- Changed: At great request set cap to 100 for LOWERMANACOST.

--- a/src/common/CScriptObj.cpp
+++ b/src/common/CScriptObj.cpp
@@ -2111,6 +2111,14 @@ TRIGRET_TYPE CScriptObj::OnTriggerScript( CScript & s, lpctstr pszTrigName, CTex
 	if ( !OnTriggerFind(s, pszTrigName) )
 		return TRIGRET_RET_DEFAULT;
 
+	/*
+	This is the same assignement found in the CChar::OnTrigger method (CCharAct.cpp).
+	If pSrc is null (for example the caster is dead when the spell triggers @EffectRemove or @EffectTick are fired) we assign the server object to it.
+	So the script can use safely use the isvalid command, otherwise Sphere will crash when accessing src in these scripts.
+	*/
+	if (!pSrc)
+		pSrc = &g_Serv;
+
 	const ProfileTask scriptsTask(PROFILE_SCRIPTS);
 
 	CScriptProfiler::CScriptProfilerTrigger	*pTrig = nullptr;

--- a/src/game/CResourceCalc.cpp
+++ b/src/game/CResourceCalc.cpp
@@ -440,7 +440,7 @@ ushort CServerConfig::Calc_SpellManaCost(CChar* pCharCaster, const CSpellDef* pS
 	const CCPropsChar* pCCPChar = pCharCaster->GetComponentProps<CCPropsChar>();
 	const CCPropsChar* pBaseCCPChar = pCharCaster->Base_GetDef()->GetComponentProps<CCPropsChar>();
 	const int iLowerManaCost = (int)pCharCaster->GetPropNum(pCCPChar, PROPCH_LOWERMANACOST, pBaseCCPChar);
-	ushort iCost = (ushort)(pSpell->m_wManaUse * (100 - minimum(iLowerManaCost, 40)) / 100);
+	ushort iCost = (ushort)(pSpell->m_wManaUse * ((100 - iLowerManaCost) / 100));
 	
 	if ( fScroll )
 		return iCost / 2; //spells cast from scrolls consume half of the mana.

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -664,14 +664,14 @@ effect_bounce:
 	if ( IsAosFlagEnabled(FEATURE_AOS_UPDATE_B) )
 	{
 		CItem * pEvilOmen = LayerFind(LAYER_SPELL_Evil_Omen);
-		if ( pEvilOmen )
+		if ( pEvilOmen && !g_Cfg.GetSpellDef(SPELL_Evil_Omen)->IsSpellType(SPELLFLAG_SCRIPTED))
 		{
 			iDmg += iDmg / 4;
 			pEvilOmen->Delete();
 		}
 
 		CItem * pBloodOath = LayerFind(LAYER_SPELL_Blood_Oath);
-		if ( pBloodOath && pBloodOath->m_uidLink == pSrc->GetUID() && !(uType & DAMAGE_FIXED) )	// if DAMAGE_FIXED is set we are already receiving a reflected damage, so we must stop here to avoid an infinite loop.
+		if ( pBloodOath && pBloodOath->m_uidLink == pSrc->GetUID() && !(uType & DAMAGE_FIXED) && !g_Cfg.GetSpellDef(SPELL_Blood_Oath)->IsSpellType(SPELLFLAG_SCRIPTED))	// if DAMAGE_FIXED is set we are already receiving a reflected damage, so we must stop here to avoid an infinite loop.
 		{
 			iDmg += iDmg / 10;
 			pSrc->OnTakeDamage(iDmg * (100 - pBloodOath->m_itSpell.m_spelllevel) / 100, this, DAMAGE_MAGIC|DAMAGE_FIXED);

--- a/src/game/chars/CCharSpell.cpp
+++ b/src/game/chars/CCharSpell.cpp
@@ -3416,7 +3416,7 @@ bool CChar::OnSpellEffect( SPELL_TYPE spell, CChar * pCharSrc, int iSkillLevel, 
 		if ( IsAosFlagEnabled(FEATURE_AOS_UPDATE_B) )
 		{
 			CItem *pEvilOmen = LayerFind(LAYER_SPELL_Evil_Omen);
-			if ( pEvilOmen )
+			if ( pEvilOmen && !g_Cfg.GetSpellDef(SPELL_Evil_Omen)->IsSpellType(SPELLFLAG_SCRIPTED))
 				uiResist /= 2;	// Effect 3: Only 50% of magic resistance used in next resistable spell.
 		}
 	}

--- a/src/game/clients/CClientMsg.cpp
+++ b/src/game/clients/CClientMsg.cpp
@@ -1199,6 +1199,10 @@ void CClient::addItemName( CItem * pItem )
 	}
 
 	HUE_TYPE wHue = HUE_TEXT_DEF;
+	const CVarDefCont* sVal = pItem->GetKey("NAME.HUE", true);
+	if (sVal)
+		wHue = (HUE_TYPE)(sVal->GetValNum());
+
 	const CItemCorpse * pCorpseItem = dynamic_cast <const CItemCorpse *>(pItem);
 	if ( pCorpseItem )
 	{


### PR DESCRIPTION


- Fixed: Crash when accessing  a non-existant SRC (the caster) in the @EffectRemove and @EffectTick triggers.
   Remember to use the ISVALID command by assigning SRC to a REF to check if the caster is still valid
- Fixed: Necromancy spells Blood Oath and Evil Omen have their default behaviour executed even if their spell definition has the SPELLFLAG_SCRIPTED set.
- Fixed: Poison memory item  was not re-created after a character was poisoned again.
- Changed: At great request set cap to 100 for LOWERMANACOST.