### PR TITLE
Fix illimited arrow with Tdata3=0 for bow

### DIFF
--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -1696,8 +1696,9 @@ WAR_SWING_TYPE CChar::Fight_Hit( CChar * pCharTarg )
         if ( pWeapon )
         {
             const CResourceID ridAmmo(pWeapon->Weapon_GetRangedAmmoRes());
-            if (ridAmmo.IsValidUID())
+			if (ridAmmo.IsUIDItem() && ridAmmo.IsValidResource()) // Illimited ammo (TDATA3=0) mean ridAmmo.IsUIDItem()=0
             {
+				
                 pAmmo = pWeapon->Weapon_FindRangedAmmo(ridAmmo);
                 if ( !pAmmo && m_pPlayer )
                 {

--- a/src/game/chars/CCharUse.cpp
+++ b/src/game/chars/CCharUse.cpp
@@ -544,7 +544,7 @@ bool CChar::Use_Train_ArcheryButte( CItem * pButte, bool fSetup )
 
 	CItem *pAmmo = nullptr;
 	const CResourceID ridAmmo(pWeapon->Weapon_GetRangedAmmoRes());
-	if (ridAmmo.IsValidUID())
+	if (ridAmmo.IsUIDItem() && ridAmmo.IsValidResource()) // Illimited ammo (TDATA3=0) mean ridAmmo.IsUIDItem()=0
 	{
 		pAmmo = pWeapon->Weapon_FindRangedAmmo(ridAmmo);
 		if ( !pAmmo )


### PR DESCRIPTION
The new verification added on this commit: https://github.com/Sphereserver/Source-X/commit/7af71186748f5059dd11a1dce6be6c3b82272b22 cause that the server think Tdata3=0 was an error because =0 is an invalid item.

Normaly, Tdata3= the ID of item you throw for example i_arrow.

On this commit, it's now permit to use and invalid item UID. But I think it's scrap the purpose of initial commit.