### PR TITLE
Fixed: Dragon breath action and Throwing Action (not the Throwing ski…

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2706,3 +2706,12 @@ Must have event, even if it's empty, since it's applied by the source to generat
 - Fixed: Necromancy spells Blood Oath and Evil Omen have their default behaviour executed even if their spell definition has the SPELLFLAG_SCRIPTED set.
 - Fixed: Poison memory item  was not re-created after a character was poisoned again. 
 - Changed: At great request set cap to 100 for LOWERMANACOST.
+
+06-06-2021, Jhobean
+- Fixed: Fix illimited arrow with Tdata3=0 for bow (Issue #698). 
+
+07-06-2021, Drk84
+- Fixed: Dragon breath action and Throwing Action (not the Throwing skill) spam.(Issue #689).
+- Fixed: Magic Trap and Magic Untrap spells not calling the @SpellEffect/@Effect triggers (Issue #697).
+- Fixed: Mind Blast not triggering effect if the spell level was equal to 0 (Issue #696).
+- Fixed: Text spam when using the AFK command (Issue #694).

--- a/src/game/chars/CCharSkill.cpp
+++ b/src/game/chars/CCharSkill.cpp
@@ -3065,7 +3065,7 @@ int CChar::Skill_Act_Napping( SKTRIG_TYPE stage )
 
 	if ( stage == SKTRIG_START )
 	{
-		_SetTimeout(2);
+		_SetTimeout(2000);
 		return 0;
 	}
 
@@ -3073,7 +3073,7 @@ int CChar::Skill_Act_Napping( SKTRIG_TYPE stage )
 	{
 		if ( m_Act_p != GetTopPoint())
 			return -SKTRIG_QTY;	// we moved.
-		_SetTimeout(8);
+		_SetTimeout(8000);
 		Speak( "z", HUE_WHITE, TALKMODE_WHISPER );
 		return -SKTRIG_STROKE;	// Stay in the skill till we hit.
 	}
@@ -3108,7 +3108,7 @@ int CChar::Skill_Act_Breath( SKTRIG_TYPE stage )
 		if ( !g_Cfg.IsSkillFlag( Skill_GetActive(), SKF_NOANIM ) )
 			UpdateAnimate( ANIM_MON_Stomp );
 
-		_SetTimeout(3);
+		_SetTimeout(3000);
 		return 0;
 	}
 
@@ -3192,7 +3192,7 @@ int CChar::Skill_Act_Throwing( SKTRIG_TYPE stage )
 		if ( !g_Cfg.IsSkillFlag( Skill_GetActive(), SKF_NOANIM ) )
 			UpdateAnimate( ANIM_MON_Stomp );
 
-		_SetTimeout(3);
+		_SetTimeout(3000);
 		return 0;
 	}
 

--- a/src/game/chars/CCharSpell.cpp
+++ b/src/game/chars/CCharSpell.cpp
@@ -2951,9 +2951,12 @@ bool CChar::Spell_CastDone()
 			break;
 
 			case SPELL_Magic_Trap:
-			case SPELL_Magic_Untrap:
 				/* Create the trap object and link it to the target.
 				   A container is diff from door or stationary object */
+				pObj->OnSpellEffect(SPELL_Magic_Trap, this, iSkillLevel, nullptr);
+				break;
+			case SPELL_Magic_Untrap:
+				pObj->OnSpellEffect(SPELL_Magic_Untrap, this, iSkillLevel, nullptr);
 				break;
 
 			case SPELL_Telekin:	// Act as DClick on the object.
@@ -3381,7 +3384,7 @@ bool CChar::OnSpellEffect( SPELL_TYPE spell, CChar * pCharSrc, int iSkillLevel, 
 	const CSpellDef * pSpellDef = g_Cfg.GetSpellDef(spell);
 	if ( !pSpellDef )
 		return false;
-	if ( iSkillLevel <= 0 )		// spell died or fizzled
+	if ( iSkillLevel < 0 )		// spell died or fizzled
 		return false;
 	if ( IsStatFlag(STATF_DEAD) && !pSpellDef->IsSpellType(SPELLFLAG_TARG_DEAD) )
 		return false;


### PR DESCRIPTION
…ll) spam.(Issue #689).

- Fixed: Magic Trap and Magic Untrap spells not calling the @SpellEffect/@Effect triggers (Issue #697).
- Fixed: Mind Blast not triggering effect if the spell level was equal to 0 (Issue #696).
- Fixed: Text spam when using the AFK command (Issue #694)