### PR TITLE
- Added: New Optional Flag in the sphere.ini, OF_AllowContainerInsideContainer:

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2735,7 +2735,11 @@ Must have event, even if it's empty, since it's applied by the source to generat
 		Return 1: Completely blocks the damage as if the parry damage reduction was set to 100.
 		
 10-06-2021, Drk84
--Fixed: Damage was always reduced by parry even if the character failed the parry action.
+- Fixed: Damage was always reduced by parry even if the character failed the parry action.
 
 29-06-2021, Drk84
--Fixed: local.arrow in @Hit and @HitMiss not storing the arrow uid.
+- Fixed: local.arrow in @Hit and @HitMiss not storing the arrow uid.
+
+01-07-2021, Drk84
+- Added: New Optional Flag in the sphere.ini, OF_AllowContainerInsideContainer:
+		 By default you cannot add a container that is heavier than the container being inserted into, enabling this flag allow the player to add any type of container inside any other container, no matter the weight.

--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2742,4 +2742,4 @@ Must have event, even if it's empty, since it's applied by the source to generat
 
 01-07-2021, Drk84
 - Added: New Optional Flag in the sphere.ini, OF_AllowContainerInsideContainer:
-		 By default you cannot add a container that is heavier than the container being inserted into, enabling this flag allow the player to add any type of container inside any other container, no matter the weight.
+		 By default you cannot add a container that is heavier than the container being inserted into, enabling this flag allow the player to add any type of container inside any other container, no matter the weight (Issue #723).

--- a/src/game/CServerConfig.cpp
+++ b/src/game/CServerConfig.cpp
@@ -4209,6 +4209,7 @@ void CServerConfig::PrintEFOFFlags(bool bEF, bool bOF, CTextConsole *pSrc)
         if ( IsSetOF(OF_StatAllowValOverMax) )		catresname(zOptionFlags, "StatAllowValOverMax");
         if ( IsSetOF(OF_GuardOutsideGuardedArea) )	catresname(zOptionFlags, "GuardOutsideGuardedArea");
         if ( IsSetOF(OF_OWNoDropCarriedItem) )		catresname(zOptionFlags, "OWNoDropCarriedItem");
+		if (IsSetOF(OF_AllowContainerInsideContainer)) catresname(zOptionFlags, "AllowContainerInsideContainer");
 
 		if ( zOptionFlags[0] != '\0' )
 		{

--- a/src/game/CServerConfig.h
+++ b/src/game/CServerConfig.h
@@ -36,29 +36,30 @@ using CServerRef = CServerDef*;
  */
 enum OF_TYPE
 {
-	OF_NoDClickTarget			= 0x0000001,    // Weapons won't open a target in the cursor after DClicking them for equip.
-	OF_NoSmoothSailing			= 0x0000002,    // Deactivate Smooth Sailing for clients >= 7.0.8.13.
-	OF_ScaleDamageByDurability	= 0x0000004,    // Weapons/armors will lose DAM/AR effect based on it's current durability.
-	OF_Command_Sysmsgs			= 0x0000008,    // Shows status of hearall, allshow, allmove... commands after toggling them.
-	OF_PetSlots					= 0x0000010,    // Enable AOS pet follower slots on chars. If enabled, all players must have MAXFOLLOWER property set (default=5).
-	OF_OSIMultiSight			= 0x0000020,    // Only send items inside multis when the player enter on the multi area.
-	OF_Items_AutoName			= 0x0000040,    // Auto rename potions/scrolls to match its spell name
-	OF_FileCommands				= 0x0000080,    // Enable the usage of FILE commands
-	OF_NoItemNaming				= 0x0000100,    // Disable the DEFMSG."grandmaster_mark" in crafted items
-	OF_NoHouseMuteSpeech		= 0x0000200,    // Players outside multis won't hear what is told inside
-	OF_NoContextMenuLOS			= 0x0000400,    // Disable LOS check to use context menus on chars
-	OF_MapBoundarySailing		= 0x0000800,    // Boats will move to the other side of the map when reach map boundary
-	OF_Flood_Protection			= 0x0001000,    // Prevent the server send messages to client if its the same message as the last already sent
-	OF_Buffs					= 0x0002000,    // Enable the buff/debuff bar on ML clients >= 5.0.2b
-	OF_NoPrefix					= 0x0004000,    // Don't show "a" and "an" prefix on item names
-	OF_DyeType					= 0x0008000,    // Allow use i_dye on all items with t_dye_vat typedef instead only on i_dye_tub itemdef
-	OF_DrinkIsFood				= 0x0010000,    // Typedef t_drink will increase food level like t_food
-	OF_NoDClickTurn				= 0x0020000,    // Don't turn the player when DClick something
-	OF_NoPaperdollTradeTitle	= 0x0040000,	// Don't show the trade title on the paperdoll
-    OF_NoTargTurn				= 0x0080000,    // Don't turn the player when targetting something
-    OF_StatAllowValOverMax      = 0x0100000,    // Allow stats value above their maximum value (i.e. allow hits value > maxhits).
-    OF_GuardOutsideGuardedArea  = 0x0200000,    // Allow guards to walk in unguarded areas, instead of being teleported back to their home point.
-    OF_OWNoDropCarriedItem      = 0x0400000     // When overweighted, don't drop items on ground when moving them (or using BOUNCE) and checking if you can carry them.
+	OF_NoDClickTarget			    = 0x0000001,    // Weapons won't open a target in the cursor after DClicking them for equip.
+	OF_NoSmoothSailing			    = 0x0000002,    // Deactivate Smooth Sailing for clients >= 7.0.8.13.
+	OF_ScaleDamageByDurability	    = 0x0000004,    // Weapons/armors will lose DAM/AR effect based on it's current durability.
+	OF_Command_Sysmsgs			    = 0x0000008,    // Shows status of hearall, allshow, allmove... commands after toggling them.
+	OF_PetSlots					    = 0x0000010,    // Enable AOS pet follower slots on chars. If enabled, all players must have MAXFOLLOWER property set (default=5).
+	OF_OSIMultiSight			    = 0x0000020,    // Only send items inside multis when the player enter on the multi area.
+	OF_Items_AutoName			    = 0x0000040,    // Auto rename potions/scrolls to match its spell name
+	OF_FileCommands				    = 0x0000080,    // Enable the usage of FILE commands
+	OF_NoItemNaming				    = 0x0000100,    // Disable the DEFMSG."grandmaster_mark" in crafted items
+	OF_NoHouseMuteSpeech		    = 0x0000200,    // Players outside multis won't hear what is told inside
+	OF_NoContextMenuLOS			    = 0x0000400,    // Disable LOS check to use context menus on chars
+	OF_MapBoundarySailing		    = 0x0000800,    // Boats will move to the other side of the map when reach map boundary
+	OF_Flood_Protection			    = 0x0001000,    // Prevent the server send messages to client if its the same message as the last already sent
+	OF_Buffs					    = 0x0002000,    // Enable the buff/debuff bar on ML clients >= 5.0.2b
+	OF_NoPrefix					    = 0x0004000,    // Don't show "a" and "an" prefix on item names
+	OF_DyeType					    = 0x0008000,    // Allow use i_dye on all items with t_dye_vat typedef instead only on i_dye_tub itemdef
+	OF_DrinkIsFood				    = 0x0010000,    // Typedef t_drink will increase food level like t_food
+	OF_NoDClickTurn				    = 0x0020000,    // Don't turn the player when DClick something
+	OF_NoPaperdollTradeTitle	    = 0x0040000,	// Don't show the trade title on the paperdoll
+    OF_NoTargTurn				    = 0x0080000,    // Don't turn the player when targetting something
+    OF_StatAllowValOverMax          = 0x0100000,    // Allow stats value above their maximum value (i.e. allow hits value > maxhits).
+    OF_GuardOutsideGuardedArea      = 0x0200000,    // Allow guards to walk in unguarded areas, instead of being teleported back to their home point.
+    OF_OWNoDropCarriedItem          = 0x0400000,     // When overweighted, don't drop items on ground when moving them (or using BOUNCE) and checking if you can carry them.
+    OF_AllowContainerInsideContainer = 0x0800000    //Allow containers inside other containers even if they are heavier than the container being inserted into.
 };
 
 /**

--- a/src/game/items/CItemContainer.cpp
+++ b/src/game/items/CItemContainer.cpp
@@ -856,7 +856,8 @@ bool CItemContainer::CanContainerHold( const CItem *pItem, const CChar *pCharMsg
 		}
 	}
 
-	if ( !IsItemEquipped() &&	// does not apply to my pack.
+	if ( !IsSetOF(OF_AllowContainerInsideContainer) &&
+		!IsItemEquipped() &&	// does not apply to my pack.
 		pItem->IsContainer() &&
 		(pItem->Item_GetDef()->GetVolume() >= Item_GetDef()->GetVolume()) )
 	{

--- a/src/sphere.ini
+++ b/src/sphere.ini
@@ -752,29 +752,30 @@ Experimental=0
 // Option flags 
 // Flags for options that affect server behaviour but not compatibility
 // See the revisions.txt file for more details on this
-// OF_NoDClickTarget			00000001 // Weapons won't open a target in the cursor after DClicking them for equip.
-// OF_NoSmoothSailing			00000002 // Deactivate Smooth Sailing for clients >= 7.0.8.13
-// OF_ScaleDamageByDurability	00000004 // Weapons/armors will lose DAM/AR effect based on it's current durability
-// OF_Command_Sysmsgs			00000008 // Shows status of hearall, allshow, allmove... commands after toggling them
-// OF_PetSlots					00000010 // Enable AOS pet follower slots on chars. If enabled, all players must have MAXFOLLOWER property set (default=5)
-// OF_OSIMultiSight				00000020 // Only send items inside multis when the player enter on the multi area
-// OF_Items_AutoName			00000040 // Auto rename potions/scrolls to match its spell name
-// OF_FileCommands				00000080 // Enable the usage of FILE commands
-// OF_NoItemNaming				00000100 // Disable the DEFMSG."grandmaster_mark" in crafted items
-// OF_NoHouseMuteSpeech			00000200 // Players outside multis won't hear what is told inside
-// OF_NoContextMenuLOS			00000400 // Disable LOS check to use context menus on chars
-// OF_MapBoundarySailing		00000800 // Boats will move to the other side of the map when reach map boundary
-// OF_Flood_Protection			00001000 // Prevent the server send messages to client if its the same message as the last already sent
-// OF_Buffs						00002000 // Enable the buff/debuff bar on ML clients >= 5.0.2b
-// OF_NoPrefix					00004000 // Don't show "a" and "an" prefix on item names
-// OF_DyeType					00008000 // Allow use i_dye on all items with t_dye_vat typedef instead only on i_dye_tub itemdef
-// OF_DrinkIsFood				00010000 // Typedef t_drink will increase food level like t_food
-// OF_NoDClickTurn				00020000 // Don't turn the player when DClick something
-// OF_NoPaperdollTradeTitle		00040000 // Don't show the trade title on the paperdoll
-// OF_NoTargTurn				00080000 // Don't turn the player when targetting something
-// OF_StatAllowValOverMax		00100000 // Allow stats value above their maximum value (i.e. allow hits value > maxhits).
-// OF_GuardOutsideGuardedArea   00200000 // Allow guards to walk in unguarded areas, instead of being teleported back to their home point.
-// OF_OWNoDropCarriedItem		00400000 // When overweighted, don't drop items on ground when moving them (or using BOUNCE) and checking if you can carry them.
+// OF_NoDClickTarget				00000001 // Weapons won't open a target in the cursor after DClicking them for equip.
+// OF_NoSmoothSailing				00000002 // Deactivate Smooth Sailing for clients >= 7.0.8.13
+// OF_ScaleDamageByDurability		00000004 // Weapons/armors will lose DAM/AR effect based on it's current durability
+// OF_Command_Sysmsgs				00000008 // Shows status of hearall, allshow, allmove... commands after toggling them
+// OF_PetSlots						00000010 // Enable AOS pet follower slots on chars. If enabled, all players must have MAXFOLLOWER property set (default=5)
+// OF_OSIMultiSight					00000020 // Only send items inside multis when the player enter on the multi area
+// OF_Items_AutoName				00000040 // Auto rename potions/scrolls to match its spell name
+// OF_FileCommands					00000080 // Enable the usage of FILE commands
+// OF_NoItemNaming					00000100 // Disable the DEFMSG."grandmaster_mark" in crafted items
+// OF_NoHouseMuteSpeech				00000200 // Players outside multis won't hear what is told inside
+// OF_NoContextMenuLOS				00000400 // Disable LOS check to use context menus on chars
+// OF_MapBoundarySailing			00000800 // Boats will move to the other side of the map when reach map boundary
+// OF_Flood_Protection				00001000 // Prevent the server send messages to client if its the same message as the last already sent
+// OF_Buffs							00002000 // Enable the buff/debuff bar on ML clients >= 5.0.2b
+// OF_NoPrefix						00004000 // Don't show "a" and "an" prefix on item names
+// OF_DyeType						00008000 // Allow use i_dye on all items with t_dye_vat typedef instead only on i_dye_tub itemdef
+// OF_DrinkIsFood					00010000 // Typedef t_drink will increase food level like t_food
+// OF_NoDClickTurn					00020000 // Don't turn the player when DClick something
+// OF_NoPaperdollTradeTitle			00040000 // Don't show the trade title on the paperdoll
+// OF_NoTargTurn					00080000 // Don't turn the player when targetting something
+// OF_StatAllowValOverMax			00100000 // Allow stats value above their maximum value (i.e. allow hits value > maxhits).
+// OF_GuardOutsideGuardedArea		00200000 // Allow guards to walk in unguarded areas, instead of being teleported back to their home point.
+// OF_OWNoDropCarriedItem			00400000 // When overweighted, don't drop items on ground when moving them (or using BOUNCE) and checking if you can carry them.
+// OF_AllowContainerInsideContainer	00800000 //Allow containers inside other containers even if they are heavier than the container being inserted into.
 OptionFlags=08|080|0200
 
 // FeatureT2A, used to control T2A expansion features ( default 03 )


### PR DESCRIPTION


   By default you cannot add a container that is heavier than the container being inserted into, enabling this flag allow the player to add any type of container inside any other container, no matter the weight.