### PR TITLE
- Added:  New TAG.OVERRIDE.SHOVE for NPCs only, if set to 1 it allowsa NPC to pass through another NPC without being blocked (Issue #715).

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2765,3 +2765,7 @@ Must have event, even if it's empty, since it's applied by the source to generat
 26-07-2021, Alex
 - Added: CONTINUECUSTOMIZE, for CustomHouses resumen lastdesign if player close dialog.
 
+30-07-2021, Drk84
+- Added:  New TAG.OVERRIDE.SHOVE for NPCs only, if set to 1 it allows a NPC to pass through another NPC without being blocked (Issue #715).
+- Fixed: Pets are now able again to damage their own owner, this wasn't noticeable unless the COMBAT_NOPETDESERT flag was enabled (Issue #724).
+

--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -3400,7 +3400,7 @@ CRegion * CChar::CanMoveWalkTo( CPointMap & ptDst, bool fCheckChars, bool fCheck
                 return nullptr; // can't walk over a statue
 			if ( (pChar == this) || (abs(pChar->GetTopZ() - ptDst.m_z) > 5) || (pChar->IsStatFlag(STATF_INSUBSTANTIAL)) )
 				continue;
-			if ( m_pNPC && pChar->m_pNPC )	// NPCs can't walk over another NPC
+			if ( m_pNPC && pChar->m_pNPC && !GetKeyNum("OVERRIDE.SHOVE", true) )	// NPCs can't walk over another NPC unless they have the TAG.OVERRIDE.SHOVE set.
 				return nullptr;
 
 			uiStamReq = 10;		// Stam consume for push the char. OSI seem to be 10% and not a fix 10

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -629,8 +629,8 @@ effect_bounce:
 		if ( (uType & DAMAGE_FIRE) && Can(CAN_C_FIRE_IMMUNE) )
 			goto effect_bounce;
 		// I can't take damage from my pets, the only exception is for BRAIN_BERSERK pets
-		if ( pSrc->m_pNPC && (pSrc->NPC_PetGetOwner() == this) && (pSrc->m_pNPC->m_Brain != NPCBRAIN_BERSERK) )
-			goto effect_bounce;
+		//if ( pSrc->m_pNPC && (pSrc->NPC_PetGetOwner() == this) && (pSrc->m_pNPC->m_Brain != NPCBRAIN_BERSERK) )
+			//goto effect_bounce;
 		if ( m_pArea )
 		{
 			if ( m_pArea->IsFlag(REGION_FLAG_SAFE) )
@@ -924,8 +924,8 @@ effect_bounce:
 			pSrc->m_pClient->addShowDamage( iDmg, (dword)(GetUID()) );
 		else
 		{
-			CChar * pSrcOwner = pSrc->GetOwner();
-			if ( pSrcOwner != nullptr )
+			CChar * pSrcOwner = pSrc->GetOwner(); 
+			if ( pSrcOwner != nullptr && pSrcOwner != this ) //If my pet damages somebody display the pop-up damage unless it's damaging me because i already received the pop-up damage on before.
 			{
 				if ( pSrcOwner->IsClientActive() )
 					pSrcOwner->m_pClient->addShowDamage( iDmg, (dword)(GetUID()) );


### PR DESCRIPTION
- Fixed: Pets are now able again to damage their own owner, this wasn't noticeable unless the COMBAT_NOPETDESERT flag was enabled (Issue #724).