### PR TITLE
Cartography Fix and New Ini Flag NPCShoveNPC

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2766,11 +2766,11 @@ Must have event, even if it's empty, since it's applied by the source to generat
 - Added: CONTINUECUSTOMIZE, for CustomHouses resumen lastdesign if player close dialog.
 
 30-07-2021, Drk84
-- Added:  New TAG.OVERRIDE.SHOVE for NPCs only, if set to 1 it allows a NPC to pass through another NPC without being blocked (Issue #715).
+- Added: New TAG.OVERRIDE.SHOVE for NPCs only, if set to 1 it allows a NPC to pass through another NPC without being blocked (Issue #715).
 - Fixed: Pets are now able again to damage their own owner, this wasn't noticeable unless the COMBAT_NOPETDESERT flag was enabled (Issue #724).
 
 01-08-2021, jkachhad
-- Implemented a new dialog section "prebutton" - Provides input processing before button triggers. This section can be utilized to check if the input is valid (obj in range, line of sight, etc..). This should reduce amount of code in each button trigger. 	
+- Added: New dialog section "prebutton" - Provides input processing before button triggers. This section can be utilized to check if the input is valid (obj in range, line of sight, etc..). This should reduce amount of code in each button trigger. 	
 Example:
 	[dialog d_test]
 	...
@@ -2784,3 +2784,10 @@ Example:
 	on=2
 	src.dex=100
 It will check if distance is > 10, so you don't need to write the distance check on every button
+
+11-08-2021, Drk84
+- Added: New Ini flag NPCShoveNPC for allowing NPCs to walkt through other NPCs, default value is 0 (still Issue #715).
+- Fixed: Cartography TDATA values were inverted, TDATA1 is actually the height while TDATA2 is the width.
+- Added: Two new override tags for cartography map items: TAG.OVERRIDE.MAPWIDTH and TAG.OVERRIDE.MAPHEIGHT
+		 You can change the size by setting a value in the TDATA1 (WIDTH) and/or TDATA2(HEIGHT) value in the map itemdef or dynamically by using TAG.OVERRIDE.MAPWIDTH and/or TAG.OVERRIDE.MAPHEIGHT.
+		 By default Sphere the default value for cartography map is 200x200 (Issue #676).

--- a/src/game/CServerConfig.cpp
+++ b/src/game/CServerConfig.cpp
@@ -119,6 +119,7 @@ CServerConfig::CServerConfig()
 	m_fGuardsOnMurderers	= true;
 	m_iSnoopCriminal		= 100;
 	m_iTradeWindowSnooping	= true;
+	m_NPCShoveNPC			= false;
 	m_iTrainSkillCost		= 1;
 	m_iTrainSkillMax		= 420;
 	m_iTrainSkillPercent	= 30;
@@ -587,6 +588,7 @@ enum RC_TYPE
 	RC_NPCCANFIZZLEONHIT,		// m_fNPCCanFizzle
     RC_NPCDISTANCEHEAR,         // m_iNPCDistanceHear
 	RC_NPCNOFAMETITLE,			// m_NPCNoFameTitle
+	RC_NPCSHOVENPC,				// m_NPCShoveNPC
 	RC_NPCSKILLSAVE,			// m_iSaveNPCSkills
 	RC_NPCTRAINCOST,			// m_iTrainSkillCost
 	RC_NPCTRAINMAX,				// m_iTrainSkillMax
@@ -839,6 +841,7 @@ const CAssocReg CServerConfig::sm_szLoadKeys[RC_QTY+1] =
 	{ "NPCCANFIZZLEONHIT",		{ ELEM_BOOL,	OFFSETOF(CServerConfig,m_fNPCCanFizzleOnHit),	0 }},
     { "NPCDISTANCEHEAR",        { ELEM_INT,     OFFSETOF(CServerConfig,m_iNPCDistanceHear),     0 }},
 	{ "NPCNOFAMETITLE",			{ ELEM_BOOL,	OFFSETOF(CServerConfig,m_NPCNoFameTitle),		0 }},
+	{ "NPCSHOVENPC",			{ ELEM_BOOL,	OFFSETOF(CServerConfig,m_NPCShoveNPC),			0 }},
 	{ "NPCSKILLSAVE",			{ ELEM_INT,		OFFSETOF(CServerConfig,m_iSaveNPCSkills),		0 }},
 	{ "NPCTRAINCOST",			{ ELEM_INT,		OFFSETOF(CServerConfig,m_iTrainSkillCost),		0 }},
 	{ "NPCTRAINMAX",			{ ELEM_INT,		OFFSETOF(CServerConfig,m_iTrainSkillMax),		0 }},

--- a/src/game/CServerConfig.h
+++ b/src/game/CServerConfig.h
@@ -535,7 +535,8 @@ public:
 
 	bool    m_bAgree;               // AGREE=n for nightly builds.
 	int     m_iMaxPolyStats;        // Max amount of each Stat gained through Polymorph spell. This affects separatelly to each stat.
-
+    
+    bool    m_NPCShoveNPC;           //NPC can walk through other NPC, by default this is disabled.
 	// End INI file options.
 
 	CResourceScript m_scpIni;       // Keep this around so we can link to it.

--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -3400,7 +3400,7 @@ CRegion * CChar::CanMoveWalkTo( CPointMap & ptDst, bool fCheckChars, bool fCheck
                 return nullptr; // can't walk over a statue
 			if ( (pChar == this) || (abs(pChar->GetTopZ() - ptDst.m_z) > 5) || (pChar->IsStatFlag(STATF_INSUBSTANTIAL)) )
 				continue;
-			if ( m_pNPC && pChar->m_pNPC && !GetKeyNum("OVERRIDE.SHOVE", true) )	// NPCs can't walk over another NPC unless they have the TAG.OVERRIDE.SHOVE set.
+			if ( m_pNPC && pChar->m_pNPC && !g_Cfg.m_NPCShoveNPC && !GetKeyNum("OVERRIDE.SHOVE", true) )	// NPCs can't walk over another NPC unless they have the TAG.OVERRIDE.SHOVE set or the NPCCanShoveNPC ini flag is enabled.
 				return nullptr;
 
 			uiStamReq = 10;		// Stam consume for push the char. OSI seem to be 10% and not a fix 10

--- a/src/network/send.cpp
+++ b/src/network/send.cpp
@@ -5214,6 +5214,14 @@ PacketDisplayMapNew::PacketDisplayMapNew(const CClient* target, const CItemMap* 
 
 	word width	= (word)(itemDef->m_ttMap.m_iGumpWidth 	> 0 ? itemDef->m_ttMap.m_iGumpWidth		:	(word)CItemMap::DEFAULT_SIZE);
 	word height = (word)(itemDef->m_ttMap.m_iGumpHeight	> 0 ? itemDef->m_ttMap.m_iGumpHeight	:	(word)CItemMap::DEFAULT_SIZE);
+	
+	word overrideWidth = (word)map->GetKeyNum("OVERRIDE.MAPWIDTH", true);
+	if (overrideWidth > 0)
+		width = overrideWidth;
+
+	word overrideHeight = (word)map->GetKeyNum("OVERRIDE.MAPHEIGHT", true);
+	if (overrideHeight > 0)
+		height = overrideHeight;
 
 	writeInt32(map->GetUID());
 	writeInt16(GUMP_MAP_2_NORTH);
@@ -5221,8 +5229,8 @@ PacketDisplayMapNew::PacketDisplayMapNew(const CClient* target, const CItemMap* 
 	writeInt16((word)(rect.m_top));
 	writeInt16((word)(rect.m_right));
 	writeInt16((word)(rect.m_bottom));
+	writeInt16(height); //the packet guide lists the width as the value sent before heigth, but in game the values are actually inverted.
 	writeInt16(width);
-	writeInt16(height);
 	writeInt16((word)(rect.m_map));
 
 	push(target);

--- a/src/sphere.ini
+++ b/src/sphere.ini
@@ -541,6 +541,9 @@ VendorMarkup=15
 // Max number of items to sell to one person at once
 VendorMaxSell=255
 
+// NPCs can walk through other NPCs
+NPCShoveNPC = 1
+
 // Cost (in gp) of each 0.1 skill trained on NPCs
 NPCTrainCost=1
 

--- a/src/sphere.ini
+++ b/src/sphere.ini
@@ -542,7 +542,7 @@ VendorMarkup=15
 VendorMaxSell=255
 
 // NPCs can walk through other NPCs
-NPCShoveNPC = 1
+NPCShoveNPC = 0
 
 // Cost (in gp) of each 0.1 skill trained on NPCs
 NPCTrainCost=1


### PR DESCRIPTION
- Added: New Ini flag NPCShoveNPC for allowing NPCs to walkt through other NPCs, default value is 0 (still Issue #715).
- Fixed: Cartography TDATA values were inverted, TDATA1 is actually the height while TDATA2 is the width.
- Added: Two new override tags for cartography map items: TAG.OVERRIDE.MAPWIDTH and TAG.OVERRIDE.MAPHEIGHT
		 You can change the size by setting a value in the TDATA1 (WIDTH) and/or TDATA2(HEIGHT) value in the map itemdef or dynamically by using TAG.OVERRIDE.MAPWIDTH and/or TAG.OVERRIDE.MAPHEIGHT.
		 By default Sphere the default value for cartography map is 200x200 (Issue #676).