### PR TITLE
Added: ARGN3 in the @ItemSmelt/@Smelt trigger, setting it to 1 will skip the…

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2822,4 +2822,6 @@ It will check if distance is > 10, so you don't need to write the distance check
 		
 		
 13-09-2021, Drk84
--Fixed: Failing the smelting consumed the whole ore/item stack instead of random amount (a value between 1 and half the stack size).
+-Fixed: Failing the smelting action consumed the whole ore/item stack instead of a random amount (a value between 1 and half the stack size).
+-Added: ARGN3 in the @ItemSmelt/@Smelt trigger, setting it to 1 will skip the minimum requirement for smelting ore to ingots.
+		By default the minimum requirement for smelting is stored in the TDATA1 property of the ingot itemdef.

--- a/src/game/chars/CCharSkill.cpp
+++ b/src/game/chars/CCharSkill.cpp
@@ -1096,6 +1096,7 @@ bool CChar::Skill_Mining_Smelt( CItem * pItemOre, CItem * pItemTarg )
 	Emote(pszMsg);
 
 	ushort iMiningSkill = Skill_GetAdjusted(SKILL_MINING);
+	bool fSkipMiningSmeltReq = false;	//Skip the minimum requirement in Mining skill for attempting the smelt action, this will be stored in ARGN3.
 	word iOreQty = pItemOre->GetAmount();
 	word iResourceQty = 0;
 	size_t iResourceTotalQty = pOreDef->m_BaseResources.size(); //This is the total amount of different resources obtained from smelting.		
@@ -1152,6 +1153,7 @@ bool CChar::Skill_Mining_Smelt( CItem * pItemOre, CItem * pItemTarg )
 	}
 
 	iMiningSkill = (ushort)Args.m_iN1;
+	fSkipMiningSmeltReq = (bool)Args.m_iN3;
 	for (size_t i = 0; i < iResourceTotalQty; ++i)
 	{
 		tchar* pszTmp = Str_GetTemp();
@@ -1188,7 +1190,7 @@ bool CChar::Skill_Mining_Smelt( CItem * pItemOre, CItem * pItemTarg )
 		}
 
 		// Try to make ingots
-		if (iMiningSkill < pBaseDef->m_ttIngot.m_iSkillMin)
+		if (iMiningSkill < pBaseDef->m_ttIngot.m_iSkillMin && !fSkipMiningSmeltReq)
 		{
 				SysMessagef(g_Cfg.GetDefaultMsg(DEFMSG_MINING_SKILL), pBaseDef->GetName());
 				if (iResourceTotalQty > 1) // This is a niche scenario where an item can provide more than one type ingots, so we continue to loop for because we can successfull get the other type of lingots.


### PR DESCRIPTION
… minimum requirement for smelting ore to ingots.

  By default the minimum requirement for smelting is stored in the TDATA1 property of the ingot itemdef.