### PR TITLE
Solutions for Issue #781 (Mana Drain)  and Issue #789 (Frozen message for older clients)

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2828,3 +2828,16 @@ It will check if distance is > 10, so you don't need to write the distance check
 - Fixed: ARGN1 value from @Hit trigger was sometime negative even if negative damage was impossible
 - Fixed: Revert 2018-03-05 Commit causing WOP no more customisable by ini and broke REVEALF_SPEAK behavior (Issue #776)
 
+02-11-2021, Drk84
+- Changed: In old clients (starting from 2.0.0 ) the "You are frozen and can not move."  will appear again when a player is paralyzed and attempting to move, thanks for a1exp for the solution.(Issue #789)
+		   Recent clients (i think from 6.0.0+) seems to block the movement request when the statf_frozen flag is applied, while clients 5.0.0+ will get the "You are frozen and can not move." 
+		   message if attempting to use the pathfinding. 
+- Changed: Mana Drain behaviour slightly changed:
+		   1)It will use its own layer (LAYER_SPELL_MANA_DRAIN, layer number 79) instead of LAYER_SPELL_STATS, in this way casting Mana Drain will not remove stat spells on the affected characters.
+		   2)The Mana Drain effect value depends if you have enabled MAGICF_OSIFORMULAS or not.
+			 If enabled the effect value is calculated from this formula: (400 + Caster Eval Int - Target Magic Resistance ) / 10. 
+			 If disabled the effect value is by default 10,30, only in this case you can overwrite the effect of Mana Drain by changing the value in the SPELLDEF  or by changing local.effect in the @SpellEffect/@Effect triggers, same for duration (default duration is 5 seconds).
+		   3)In both cases the mana lost is temporary! If you want to get a permanent drain effect just use the following script under the Mana Drain SPELLDEF
+			 
+			 ON=@EffectRemove
+			 return 0	//Return 0 will prevent the recover mana  behaviour of the Mana Spell but the Mana Drain spell item will still be destroyed.

--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2832,7 +2832,7 @@ It will check if distance is > 10, so you don't need to write the distance check
 - Changed: In old clients (starting from 2.0.0 ) the "You are frozen and can not move."  will appear again when a player is paralyzed and attempting to move, thanks for a1exp for the solution.(Issue #789)
 		   Recent clients (i think from 6.0.0+) seems to block the movement request when the statf_frozen flag is applied, while clients 5.0.0+ will get the "You are frozen and can not move." 
 		   message if attempting to use the pathfinding. 
-- Changed: Mana Drain behaviour slightly changed:
+- Changed: Mana Drain behaviour slightly changed: (Issue #781)
 		   1)It will use its own layer (LAYER_SPELL_MANA_DRAIN, layer number 79) instead of LAYER_SPELL_STATS, in this way casting Mana Drain will not remove stat spells on the affected characters.
 		   2)The Mana Drain effect value depends if you have enabled MAGICF_OSIFORMULAS or not.
 			 If enabled the effect value is calculated from this formula: (400 + Caster Eval Int - Target Magic Resistance ) / 10. 

--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2841,3 +2841,8 @@ It will check if distance is > 10, so you don't need to write the distance check
 			 
 			 ON=@EffectRemove
 			 return 0	//Return 0 will prevent the recover mana  behaviour of the Mana Spell but the Mana Drain spell item will still be destroyed.
+			Remember to update your scripts by changing 
+			In spells_magery.scp file: 
+			LAYER = LAYER_SPELL_STATS to LAYER = LAYER_SPELL_MANA_DRAIN 
+			In your defs.scp file:
+			LAYER_SPELL_Mana_Drain			79

--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -3329,7 +3329,7 @@ CRegion * CChar::CanMoveWalkTo( CPointMap & ptDst, bool fCheckChars, bool fCheck
 {
 	ADDTOCALLSTACK("CChar::CanMoveWalkTo");
 
-	if ( Can(CAN_C_NONMOVER|CAN_C_STATUE) || IsStatFlag(STATF_FREEZE|STATF_STONE) )
+	if ( Can(CAN_C_NONMOVER|CAN_C_STATUE) ) //|| IsStatFlag(STATF_FREEZE|STATF_STONE) ) this part of condition does not seem necessary?
 		return nullptr;
 
 	int iWeightLoadPercent = GetWeightLoadPercent(GetTotalWeight());

--- a/src/game/chars/CCharSpell.cpp
+++ b/src/game/chars/CCharSpell.cpp
@@ -1591,7 +1591,9 @@ void CChar::Spell_Effect_Add( CItem * pSpell )
 			{
 				if ( pCaster != nullptr )
 				{
-                    wStatEffectRef = (400 + pCaster->Skill_GetBase(SKILL_EVALINT) - Skill_GetBase(SKILL_MAGICRESISTANCE)) / 10;
+					if ( IsSetMagicFlags(MAGICF_OSIFORMULAS) )
+						 wStatEffectRef = (400 + pCaster->Skill_GetBase(SKILL_EVALINT) - Skill_GetBase(SKILL_MAGICRESISTANCE)) / 10;
+
 					if ( wStatEffectRef > Stat_GetVal(STAT_INT) )
                         wStatEffectRef = (word)(Stat_GetVal(STAT_INT));
 				}
@@ -3676,7 +3678,6 @@ bool CChar::OnSpellEffect( SPELL_TYPE spell, CChar * pCharSrc, int iSkillLevel, 
 		case SPELL_Cunning:
 		case SPELL_Strength:
 		case SPELL_Bless:
-		case SPELL_Mana_Drain:
 		case SPELL_Mass_Curse:
 			Spell_Effect_Create( spell, fPotion ? LAYER_FLAG_Potion : LAYER_SPELL_STATS, iEffect, iDuration, pCharSrc );
 			break;
@@ -3693,7 +3694,9 @@ bool CChar::OnSpellEffect( SPELL_TYPE spell, CChar * pCharSrc, int iSkillLevel, 
 		case SPELL_Reactive_Armor:
 			Spell_Effect_Create( spell, LAYER_SPELL_Reactive, iEffect, iDuration, pCharSrc );
 			break;
-
+		case SPELL_Mana_Drain:
+			Spell_Effect_Create(spell, LAYER_SPELL_Mana_Drain, iEffect, iDuration, pCharSrc);
+			break;
 		case SPELL_Magic_Reflect:
 			Spell_Effect_Create( spell, LAYER_SPELL_Magic_Reflect, iEffect, iDuration, pCharSrc );
 			break;

--- a/src/game/uo_files/uofiles_enums.h
+++ b/src/game/uo_files/uofiles_enums.h
@@ -551,6 +551,8 @@ enum LAYER_TYPE		// defined by UO. Only one item can be in a slot.
     LAYER_SPELL_Spell_Plague,
     LAYER_SPELL_Nether_Cyclone,
 
+    //Individual Spell Layers
+    LAYER_SPELL_Mana_Drain,
     LAYER_QTY
 };
 


### PR DESCRIPTION
- Changed: In old clients (starting from 2.0.0 ) the "You are frozen and can not move."  will appear again when a player is paralyzed and attempting to move, thanks for a1exp for the solution.(Issue #789)
		   Recent clients (i think from 6.0.0+) seems to block the movement request when the statf_frozen flag is applied, while clients 5.0.0+ will get the "You are frozen and can not move." 
		   message if attempting to use the pathfinding. 
- Changed: Mana Drain behaviour slightly changed: (Issue #781)
		   1)It will use its own layer (LAYER_SPELL_MANA_DRAIN, layer number 79) instead of LAYER_SPELL_STATS, in this way casting Mana Drain will not remove stat spells on the affected characters.
		   2)The Mana Drain effect value depends if you have enabled MAGICF_OSIFORMULAS or not.
			 If enabled the effect value is calculated from this formula: (400 + Caster Eval Int - Target Magic Resistance ) / 10. 
			 If disabled the effect value is by default 10,30, only in this case you can overwrite the effect of Mana Drain by changing the value in the SPELLDEF  or by changing local.effect in the @SpellEffect/@Effect triggers, same for duration (default duration is 5 seconds).
		   3)In both cases the mana lost is temporary! If you want to get a permanent drain effect just use the following script under the Mana Drain SPELLDEF
			 
			 ON=@EffectRemove
			 return 0	//Return 0 will prevent the recover mana  behaviour of the Mana Spell but the Mana Drain spell item will still be destroyed.