### PR TITLE
Possible fix for issue #804:  Incorrect EVAL parsing in case of multiple subtraction.

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2855,3 +2855,6 @@ It will check if distance is > 10, so you don't need to write the distance check
 - Fixed: Sector not going to sleep and @RegPeriodic and @CliPeriodic not firing (Issues #801 and #765).
 - Fixed: CONT not always updating the item in the new position (Issue #680).
 - Changed: Increased default MaxSizeClientOut default value to 80.000.
+
+01-12-2021, Drk84
+- Fixed: Incorrect EVAL parsing in case of multiple subtraction (Issue #804).

--- a/src/common/CExpression.cpp
+++ b/src/common/CExpression.cpp
@@ -934,9 +934,9 @@ llong CExpression::GetValMath( llong llVal, lpctstr & pExpr )
 			break;
 
 		case '-':
-			++pExpr;
 			llValSecond = GetVal(pExpr);
-			llVal -= llValSecond;
+			++pExpr; // by moving the expression after getting the second value we avoid losing the negative sign.
+			llVal += llValSecond; // a subtraction is an addiction with a negative number.
 			break;
 
 		case '*':


### PR DESCRIPTION
The original code for handling subtraction was:

```
++pExpr;

llValSecond = GetVal(pExpr);

llVal -= llValSecond;

break;
```


So when we have something like:
50 - 40 - 10 
We would lose the - before the 40 because ++pExpr will move the expression to 40 - 10  instead of -40 - 10 and we will get a result of 30 instead of -50.

So i changed the code to:

```
llValSecond = GetVal(pExpr);

++pExpr; // by moving the expression after getting the second value we avoid losing the negative sign.

llVal += llValSecond; // a subtraction is an addiction with a negative number.

break;
```



