### PR TITLE
Add possibility to see ridden mount in debug mode

### DIFF
--- a/src/game/clients/CClient.cpp
+++ b/src/game/clients/CClient.cpp
@@ -321,8 +321,8 @@ bool CClient::CanSee( const CObjBaseTemplate * pObj ) const
         {
             if( !IsPriv(PRIV_ALLSHOW) )
                 return false;
-            //dont show pet when is ridden (cause double)
-            else if ( pChar->IsStatFlag(STATF_PET) && pChar->IsStatFlag(STATF_RIDDEN) )
+            //dont show pet when is ridden (cause double). Exception in debug mode you see it
+            else if ( pChar->IsStatFlag(STATF_PET) && pChar->IsStatFlag(STATF_RIDDEN) && !IsPriv(PRIV_DEBUG))
                 return false;
         }
 	}


### PR DESCRIPTION
When you ride a mount, your NPC stay alive and next to you. For now it was impossible to see it.
Allshow do not permit to see mount since this commit (https://github.com/Sphereserver/Source-X/commit/ccb28e4269504127904e7b66331d7fc42021cea7) (It's a good thing because .allshow on heavy loaded disconnect place it was anarchy).

 I just added a priv_debug to be able to see it in combinaison of .debug + .allshow