### PR TITLE
Fix: @personnalspace was trigger when NPC pathfinding on you

### DIFF
--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -3411,7 +3411,7 @@ CRegion * CChar::CanMoveWalkTo( CPointMap & ptDst, bool fCheckChars, bool fCheck
 				uiStamReq = 0;
 
 			TRIGRET_TYPE iRet = TRIGRET_RET_DEFAULT;
-			if ( IsTrigUsed(TRIGGER_PERSONALSPACE) )
+			if ( IsTrigUsed(TRIGGER_PERSONALSPACE) && (!fPathFinding)) //You want avoid to trig the trigger if it's only a pathfinding evaluation
 			{
 				CScriptTriggerArgs Args(uiStamReq);
 				iRet = pChar->OnTrigger(CTRIG_PersonalSpace, this, &Args);


### PR DESCRIPTION
When pathfinding is active on NPC, server simulate lot of potential way to walk for each npc.

When server evaluate a walk on someone, the @personnalspace trigger was trig and not suppose too because you have nobody on you.

You can see bug HERE:
https://cdn.discordapp.com/attachments/476635430821953567/935178046531584010/personalspace.gif