### PR TITLE
Fixed:  Items falling on the floor even if you are not overweight, and Bug related to the previous commits.

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2945,3 +2945,8 @@ Note: The only way the server has to know if the bankself is closed is to store 
 06-06-2022, Drk84
 - Changed: Equipped items falling on the ground when overweight, now they will remain equipped until you lose some weight on the backpack (Issue #861).
 - Updated SphereCrypt.ini.
+
+07-06-2022, Drk84
+- Fixed:  Items falling on the floor even if you are not overweight, only for ores right now. (Issue #810).
+- Fixed:  Bug related to the previous commits.
+	

--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -1923,7 +1923,7 @@ bool CChar::ItemBounce( CItem * pItem, bool fDisplayMsg )
 			}
 		}
 	}
-	else if (pItem->GetEquipLayer() <= LAYER_LEGS) //If we are overweight, we don't want our equipped items to fall on the ground. They will remain equipped.
+	else if ( pItem->GetEquipLayer() > LAYER_NONE && pItem->GetEquipLayer() <= LAYER_LEGS) //If we are overweight, we don't want our equipped items to fall on the ground. They will remain equipped.
 	{
 		SysMessageDefault(DEFMSG_MSG_HEAVY);
 		return false;

--- a/src/game/chars/CCharSkill.cpp
+++ b/src/game/chars/CCharSkill.cpp
@@ -1154,6 +1154,7 @@ bool CChar::Skill_Mining_Smelt( CItem * pItemOre, CItem * pItemTarg )
 
 	iMiningSkill = (ushort)Args.m_iN1;
 	fSkipMiningSmeltReq = (bool)Args.m_iN3;
+	std::vector<CItem*> ingots;
 	for (size_t i = 0; i < iResourceTotalQty; ++i)
 	{
 		tchar* pszTmp = Str_GetTemp();
@@ -1213,17 +1214,34 @@ bool CChar::Skill_Mining_Smelt( CItem * pItemOre, CItem * pItemTarg )
 			return false;
 		}
 		// Payoff - Amount of ingots i get.
-		CItem * pIngots = CItem::CreateScript(pBaseDef->GetID(), this );
+		ingots.emplace_back(CItem::CreateScript(pBaseDef->GetID(), this));
+		if (ingots.at(i) == nullptr)
+		{
+			SysMessageDefault(DEFMSG_MINING_NOTHING);
+			continue;
+		}
+		ingots.at(i)->SetAmount(iResourceQty);
+		/* 
+		CItem* pIngots = CItem::CreateScript(pBaseDef->GetID(), this);
 		if ( pIngots == nullptr )
 		{
 			SysMessageDefault( DEFMSG_MINING_NOTHING );
 			continue;
 		}
 		pIngots->SetAmount(iResourceQty);
-		ItemBounce( pIngots );
-	}
 
+		ItemBounce( pIngots );
+		*/
+
+		
+	}
+	//We want to consume the ore before the ingots are created.
 	pItemOre->ConsumeAmount(pItemOre->GetAmount());
+
+	//Now we finally create the resources obtained from the smelting process.
+	for (std::vector<CItem*>::iterator ingot = ingots.begin(); ingot != ingots.end(); ++ingot)
+		ItemBounce((*ingot));
+
 	return true;
 }
 

--- a/src/game/chars/CCharStatus.cpp
+++ b/src/game/chars/CCharStatus.cpp
@@ -269,7 +269,7 @@ bool CChar::CanCarry( const CItem *pItem ) const
     {
         /*
 		If we're dragging the item, its weight is already added on char so don't count it again.
-		Same if we are already carrying the item, don't count the item again.
+		Same if we are already wearing the item, don't count the item weight again.
 		*/
         iItemWeight = pItem->GetWeight();
     }


### PR DESCRIPTION
Fixed: Items falling on the floor even if you are not overweight, only for ores right now. (Issue #810).

Fixed:  Bug related to the previous commit.