### PR TITLE
Fix "Timer expired without DECAY" cause by lasts commits

### DIFF
--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -1812,7 +1812,8 @@ int CChar::ItemPickup(CItem * pItem, word amount)
 	{
         // Create an leftover item when pick up only part of the stack
         CItem* pItemNew = pItem->UnStackSplit(amount, this);
-		pItemNew->SetTimeout(pItem->GetDecayTime());    // Set it's timer to the real decay, in case it gets forced to be drop on ground.
+		if (pItemNew->IsAttr(ATTR_DECAY)) //Don't set timer if item stay in the bag because causing error on Login.
+			pItemNew->SetTimeout(pItem->GetDecayTime());    // Set it's timer to the real decay, in case it gets forced to be drop on ground.
 
         if (IsTrigUsed(TRIGGER_PICKUP_STACK) || IsTrigUsed(TRIGGER_ITEMPICKUP_STACK))
         {


### PR DESCRIPTION


This commit added some timer check and verify that split stack always have correct timer.
https://github.com/Sphereserver/Source-X/commit/0268aad46a4487ea3cf91759bdb036e65b3e0080

unfortunately, time was set if you split stack on backpack. Yhat was causing timer fix at 0 and a error on the next login
![image](https://user-images.githubusercontent.com/51728381/172735781-ccb4ed31-e304-40e2-9a20-186687fc985d.png)

This fix prevent the error.