### PR TITLE
Screensize.Y returning wrong value with clients > 5.00.00 (Issue #630).

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2956,3 +2956,9 @@ Note: The only way the server has to know if the bankself is closed is to store 
 09-06-2022, Drk84
 - Fixed: NPCs canceling other npcs from hearing player speech (Issue #859).
 - Fixed: Undefined keyword 'shipturnleft'  (Issue #860). 
+
+25-06-2022, Drk84
+- Fixed: Screensize.Y returning wrong value with clients > 5.00.00 (Issue #630).
+		 The following resolution are supported: 640 x 480 (default) - 800x600 - 1024x768 - 1152x864 - 1280x720
+		 More can be added if needed, remember that if the user changes the resolution in game he will get the changed resolution values only when he restarts the client.
+			

--- a/src/network/receive.cpp
+++ b/src/network/receive.cpp
@@ -2554,7 +2554,27 @@ bool PacketScreenSize::onReceive(CNetState* net)
     skip(2);
 
 	//DEBUG_MSG(("PacketScreenSize::onReceive 0x%hx - 0x%hx (%hu-%hu)\n", x, y, x, y));
-
+	if (net->isClientVersion(MINCLIVER_NEWBOOK))
+	{
+		switch (x)
+		{
+		case 800:
+			y = 600;
+			break;
+		case 1024:
+			y = 768;
+			break;
+		case 1152:
+			y = 864;
+			break;
+		case 1280:
+			y = 720;
+			break;
+		default:
+			y = 480;
+			break;
+		}
+	}
 	client->SetScreenSize(x, y);
 	return true;
 }


### PR DESCRIPTION
 Fixed: Screensize.Y returning wrong value with clients > 5.00.00 (Issue #630).
		 The following resolution are supported: 640 x 480 (default) - 800x600 - 1024x768 - 1152x864 - 1280x720
		 More can be added if needed, remember that if the user changes the resolution in game he will get the changed resolution values only when he restarts the client.