### PR TITLE
- Fixed: Summoned ridden creatures did not disappear when the Summon Spell timer expired until they were dismounted (Issue #582).

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2961,4 +2961,8 @@ Note: The only way the server has to know if the bankself is closed is to store 
 - Fixed: Screensize.Y returning wrong value with clients > 5.00.00 (Issue #630).
 		 The following resolution are supported: 640 x 480 (default) - 800x600 - 1024x768 - 1152x864 - 1280x720
 		 More can be added if needed, remember that if the user changes the resolution in game he will get the changed resolution values only when he restarts the client.
-			
+
+
+30-06-2022, Drk84
+- Fixed: Summoned ridden creatures did not disappear when the Summon Spell timer expired until they were dismounted (Issue #582).
+- Fixed: When using Elemental Resistance setting Protection spell with the SPELLFLAG_SCRIPT still called the default Protection behaviour when resisting a spell. 

--- a/src/game/chars/CChar.cpp
+++ b/src/game/chars/CChar.cpp
@@ -519,7 +519,9 @@ void CChar::SetDisconnected(CSector* pNewSector)
         return;
 
 	// If the char goes offline, we don't want its items to tick anymore when the timer expires.
-	_GoSleep();
+	// Unless it's a summoned creature that we are riding.
+	if (!IsStatFlag(STATF_RIDDEN|STATF_CONJURED|STATF_PET))
+		_GoSleep();
 
     RemoveFromView();	// Remove from views.
     MoveToRegion(nullptr, false);

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -838,7 +838,7 @@ effect_bounce:
 		if ( pSpellDef && pSpellDef->GetPrimarySkill(&iSpellSkill) )
 			iDisturbChance = pSpellDef->m_Interrupt.GetLinear(Skill_GetBase((SKILL_TYPE)iSpellSkill));
 
-		if ( iDisturbChance && IsSetCombatFlags(COMBAT_ELEMENTAL_ENGINE) )
+		if ( iDisturbChance && IsSetCombatFlags(COMBAT_ELEMENTAL_ENGINE) && !pSpellDef->IsSpellType(SPELLFLAG_SCRIPTED) ) //If Protection spell has SPELLFLAG_SCRIPTED don't make this check.
 		{
 			// Protection spell can cancel the disturb
 			CItem *pProtectionSpell = LayerFind(LAYER_SPELL_Protection);


### PR DESCRIPTION
- Fixed: Summoned ridden creatures did not disappear when the Summon Spell timer expired until they were dismounted (Issue #582).
- Fixed: When using Elemental Resistance setting, Protection spell with the SPELLFLAG_SCRIPT still called the default Protection behaviour when resisting a spell.