### PR TITLE
- Fixed: Ugly workaround for the ONAME property bug (Issue #825).

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2962,7 +2962,9 @@ Note: The only way the server has to know if the bankself is closed is to store 
 		 The following resolution are supported: 640 x 480 (default) - 800x600 - 1024x768 - 1152x864 - 1280x720
 		 More can be added if needed, remember that if the user changes the resolution in game he will get the changed resolution values only when he restarts the client.
 
-
 30-06-2022, Drk84
 - Fixed: Summoned ridden creatures did not disappear when the Summon Spell timer expired until they were dismounted (Issue #582).
-- Fixed: When using Elemental Resistance setting Protection spell with the SPELLFLAG_SCRIPT still called the default Protection behaviour when resisting a spell. 
+- Fixed: When using Elemental Resistance setting, Protection spell with the SPELLFLAG_SCRIPT still called the default Protection behaviour when resisting a spell. 
+
+08-07-2022, Drk84
+- Fixed: Ugly workaround for the ONAME property bug (Issue #825).

--- a/src/common/CScript.cpp
+++ b/src/common/CScript.cpp
@@ -23,7 +23,9 @@ bool CScriptKey::IsKey( lpctstr pszName ) const
 bool CScriptKey::IsKeyHead( lpctstr pszName, size_t len ) const
 {
 	ASSERT(m_pszKey);
-	return ( ! strnicmp( m_pszKey, pszName, len ));
+	if (!strnicmp(m_pszKey, "ONAME", 5))
+		return false; //Ugly workaround for the ONAME property problem.
+	return ( ! strnicmp( m_pszKey, pszName, len ) );
 }
 
 void CScriptKey::InitKey()


### PR DESCRIPTION
Pratically when a character/item section is loaded and Sphere finds a property that starts with ON it will stop to load the object and it will delete it because it thinks it found the start of a trigger section.