### PR TITLE
Make IT_Musical equipable if it's write in the tiledata

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -2968,3 +2968,6 @@ Note: The only way the server has to know if the bankself is closed is to store 
 
 08-07-2022, Drk84
 - Fixed: Ugly workaround for the ONAME property bug (Issue #825).
+
+24-07-2022, Jhobean
+- Added: In the case you force some T_musical item equipable in the tiledata, you were not able to equip it because server fixed T_musical item not equipable.

--- a/src/game/components/CCPropsItemWeapon.cpp
+++ b/src/game/components/CCPropsItemWeapon.cpp
@@ -33,7 +33,7 @@ static bool CanSubscribeTypeIW(IT_TYPE type)
 {
     return (type == IT_WEAPON_AXE || type == IT_WEAPON_BOW || type == IT_WEAPON_FENCE || type == IT_WEAPON_MACE_CROOK || type == IT_WEAPON_MACE_PICK || type == IT_WEAPON_MACE_SHARP ||
         type == IT_WEAPON_MACE_SMITH || type == IT_WEAPON_MACE_STAFF || type == IT_WEAPON_SWORD || type == IT_WEAPON_THROWING || type == IT_WEAPON_WHIP || type == IT_WEAPON_XBOW ||
-        type == IT_FISH_POLE);
+        type == IT_FISH_POLE || type == IT_MUSICAL);
 }
 
 bool CCPropsItemWeapon::CanSubscribe(const CItemBase* pItemBase) // static

--- a/src/game/items/CItemBase.cpp
+++ b/src/game/items/CItemBase.cpp
@@ -365,6 +365,7 @@ bool CItemBase::IsTypeEquippable(IT_TYPE type, LAYER_TYPE layer) noexcept // sta
         case IT_LIGHT_LIT:
         case IT_LIGHT_OUT:	// Torches and lanterns.
         case IT_FISH_POLE:
+		case IT_MUSICAL:
         case IT_HAIR:
         case IT_BEARD:
         case IT_JEWELRY:


### PR DESCRIPTION
Prapilk made some animation of instrument:
https://www.servuo.com/archive/music-instrument.1738/

I made the change on tiledata and server was not able to equip either....
![image](https://user-images.githubusercontent.com/51728381/180656415-d01ebf35-91ea-4f8a-9792-1afbd0437eb1.png)

It's cool but the only way to be able equip it was by changing the type. For the server keeping t_musical block the equip. 

With this Pull request modification, I have permission to equip t_musical and see the object 2 hand (layer 2) so I cant wear a dagger in the right hand.

I made some test with a non-wearable t_musical. EX:  i_flute_bamboo. All work normally because the flag "wearable" is not check on tile data.