### PR TITLE
Fix listing components by duplicate and houses lockdowns

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -3028,7 +3028,8 @@ Note: The only way the server has to know if the bankself is closed is to store 
 [sphereCrypt.ini]: Added crypt key for classic client 7.0.96 and enhanced client 4.0.95, 4.0.96
 - Added: Complex maths to be able to use negative values with SQRT or POW.
 - Added: TAG.NAMELOC.HUE to use HTML colored names for items/chars with tooltips. (Issue #390)
-		 Example: TAG.NAMELOC.HUE = #FFFF00
+		 Example: TAG.NAMELOC.HUE = FF00FF // Color of the name: violet
+		 This will be internally expanded to: <basefont color=#FF00FF><name></basefont>
 - Fixed: Statues getting all wrong when updating the char, possibly don't need to be updated with addCharMove. (Issue #716)
 - Fixed: Character list was filling faster than the actual removal of the character. (Issue #753)
 - Fixed: Removing a secured container from a multi didn't work. (Issue #685)

--- a/src/game/clients/CClientMsg_AOSTooltip.cpp
+++ b/src/game/clients/CClientMsg_AOSTooltip.cpp
@@ -225,18 +225,20 @@ void CClient::AOSTooltip_addName(CObjBase* pObj)
 		else if ( (pItem->GetAmount() > 1) && (pItem->GetType() != IT_CORPSE) )
 		{
             PUSH_FRONT_TOOLTIP(pItem, t = new CClientTooltip(1050039)); // ~1_NUMBER~ ~2_ITEMNAME~
-			if (lpHue)
-				t->FormatArgs("<basefont color=\"%s\">%" PRIu16 "\t%s</basefont>", lpHue, pItem->GetAmount(), pObj->GetName());
-			else
+			if ( lpHue ) {
+				t->FormatArgs("<basefont color=\"#%s\"> %" PRIu16 "\t%s </basefont>", lpHue, pItem->GetAmount(), pObj->GetName());
+			} else {
 				t->FormatArgs("%" PRIu16 "\t%s", pItem->GetAmount(), pObj->GetName());
+			}
 		}
 		else
 		{
             PUSH_FRONT_TOOLTIP(pItem, t = new CClientTooltip(1042971)); // ~1_NOTHING~
-			if (lpHue)
-				t->FormatArgs("<basefont color=\"%s\">%s</basefont>", lpHue, pObj->GetName());
-			else
+			if ( lpHue ) {
+				t->FormatArgs("<basefont color=\"#%s\"> %s </basefont>", lpHue, pObj->GetName());
+			} else {
 				t->FormatArgs("%s", pObj->GetName());
+			}
 		}
 	}
 	else if (pChar)
@@ -277,9 +279,9 @@ void CClient::AOSTooltip_addName(CObjBase* pObj)
         PUSH_FRONT_TOOLTIP(pChar, t = new CClientTooltip(1050045)); // ~1_PREFIX~~2_NAME~~3_SUFFIX~
 		if (lpHue) {
 			if (dwClilocName) {
-				t->FormatArgs("<basefont color=\"%s\">%s\t%u\t%s</basefont>", lpHue, lpPrefix, dwClilocName, lpSuffix);
+				t->FormatArgs("<basefont color=\"#%s\"> %s\t%u\t%s </basefont>", lpHue, lpPrefix, dwClilocName, lpSuffix);
 			} else {
-				t->FormatArgs("<basefont color=\"%s\">%s\t%s\t%s</basefont>", lpPrefix, pObj->GetName(), lpSuffix);
+				t->FormatArgs("<basefont color=\"#%s\"> %s\t%s\t%s </basefont>", lpHue, lpPrefix, pObj->GetName(), lpSuffix);
 			}
 		} else {
 			if (dwClilocName) {

--- a/src/game/components/CCMultiMovable.cpp
+++ b/src/game/components/CCMultiMovable.cpp
@@ -143,7 +143,7 @@ uint CCMultiMovable::ListObjs(CObjBase ** ppObjList)
     // second add the components of the multi.
     for (size_t i = 0; i < pMulti->_lComps.size(); ++i)
     {
-        CItem* pItemComp = pMulti->_lComps[i].ItemFind();
+        CItem *pItemComp = pMulti->_lComps[i].ItemFind();
         if (!pItemComp)
             continue;
         if (!pMulti->Multi_IsPartOf(pItemComp))
@@ -158,7 +158,7 @@ uint CCMultiMovable::ListObjs(CObjBase ** ppObjList)
     AreaChar.SetSearchSquare(true);
     while (uiCount < MAX_MULTI_LIST_OBJS)
     {
-        CChar * pChar = AreaChar.GetChar();
+        CChar *pChar = AreaChar.GetChar();
         if (pChar == nullptr)
             break;
         if (!pMulti->GetRegion()->IsInside2d(pChar->GetTopPoint()))
@@ -178,25 +178,26 @@ uint CCMultiMovable::ListObjs(CObjBase ** ppObjList)
     AreaItem.SetSearchSquare(true);
     while (uiCount < MAX_MULTI_LIST_OBJS)
     {
-        CItem * pItem = AreaItem.GetItem();
+        CItem *pItem = AreaItem.GetItem();
         if (pItem == nullptr)
             break;
         if (pItem == pItemThis)	// already listed.
             continue;
-        if (!pMulti->Multi_IsPartOf(pItem))
-        {
-            if (!pMulti->GetRegion()->IsInside2d(pItem->GetTopPoint()))
-                continue;
+        if (pMulti->Multi_IsPartOf(pItem)) // already listed.
+            continue;
+        
+        if (!pMulti->GetRegion()->IsInside2d(pItem->GetTopPoint()))
+            continue;
 
-            //I guess we can allow items to be locked on the ships and still move... but disallow attr_static from moving
-            //if ( ! pItem->IsMovable() && !pItem->IsType(IT_CORPSE))
-            if (pItem->IsAttr(ATTR_STATIC))
-                continue;
+        //I guess we can allow items to be locked on the ships and still move... but disallow attr_static from moving
+        //if ( ! pItem->IsMovable() && !pItem->IsType(IT_CORPSE))
+        if (pItem->IsAttr(ATTR_STATIC))
+            continue;
 
-            int zdiff = pItem->GetTopZ() - iShipHeight;
-            if ((zdiff < -2) || (zdiff > PLAYER_HEIGHT))
-                continue;
-        }
+        int zdiff = pItem->GetTopZ() - iShipHeight;
+        if ((zdiff < -2) || (zdiff > PLAYER_HEIGHT))
+            continue;
+
         ppObjList[uiCount++] = pItem;
     }
     return uiCount;


### PR DESCRIPTION
By mistake I forgot to remove boat components from being listed twice on the item loops. This fixes it.