### PR TITLE
Little Fixes (Non Tested yet)

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -3035,3 +3035,7 @@ Note: The only way the server has to know if the bankself is closed is to store 
 - Fixed: Removing a secured container from a multi didn't work. (Issue #685)
 - Fixed: Moving multis now will add components as first priority to avoid dropping them. (Issue #821)
 - Changed: Skills with SKF_GATHER, @Start/@SkillStart, now ACT is the Worldgem Bit we're gathering from.
+
+
+11/09/2022 Tolokio
+-Removed check that denied vendor to use layer_special to keep bought items. Only pets vendors were allow. (should be the opposite maybe?)

--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -3052,7 +3052,7 @@ void CChar::SleepStart( bool fFrontFall )
 	if (IsStatFlag(STATF_DEAD|STATF_POLYMORPH))
 		return;
 	if (IsStatFlag(STATF_SLEEPING))
-		wake()
+		wake();
 		return;
 
 	CItemCorpse *pCorpse = MakeCorpse(fFrontFall);

--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -2766,6 +2766,8 @@ bool CChar::Horse_Mount(CChar *pHorse)
 	LayerAdd(pMountItem, LAYER_HORSE);	// equip the horse item
 	pHorse->StatFlag_Set(STATF_RIDDEN);
 	pHorse->Skill_Start(NPCACT_RIDDEN);
+	pHorse->SetTopZ(-127);
+	//pHorse->SetDisconnected();
 	return true;
 }
 

--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -3093,6 +3093,17 @@ bool CChar::Death()
 			return true;
 	}
 
+	if (IsStatFlag(STATF_RIDDEN))
+	{
+		CItem* pMountItem = m_atRidden.m_uidFigurine.ItemFind();
+		if (pMountItem)
+		{
+			CChar* const pRider = Horse_GetMountChar();
+			if (pRider)
+				pRider->Horse_UnMount();
+		}
+	}
+
 	// Look through memories of who I was fighting (make sure they knew they where fighting me)
 	for (CSObjContRec* pObjRec : GetIterationSafeContReverse())
 	{

--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -3049,7 +3049,10 @@ void CChar::Wake()
 void CChar::SleepStart( bool fFrontFall )
 {
 	ADDTOCALLSTACK("CChar::SleepStart");
-	if (IsStatFlag(STATF_DEAD|STATF_SLEEPING|STATF_POLYMORPH))
+	if (IsStatFlag(STATF_DEAD|STATF_POLYMORPH))
+		return;
+	if (IsStatFlag(STATF_SLEEPING))
+		wake()
 		return;
 
 	CItemCorpse *pCorpse = MakeCorpse(fFrontFall);

--- a/src/game/chars/CCharStatus.cpp
+++ b/src/game/chars/CCharStatus.cpp
@@ -1319,15 +1319,12 @@ bool CChar::CanTouch( const CObjBase *pObj ) const
                 fFreezeImmune = true;
             break;
         }
-
-        case IT_ARCHERY_BUTTE:
+	case IT_ARCHERY_BUTTE:
         {
             const CItem * pWeapon = m_uidWeapon.ItemFind();
-            if (pWeapon)
+            if (pWeapon) //only a weapons is required, butte do the rest.
             {
-                IT_TYPE iType = pWeapon->GetType();
-                if ((iType == IT_WEAPON_BOW) || (iType == IT_WEAPON_XBOW))
-                    return (iDist <= pWeapon->GetRangeH());
+                    return iDist <= 16; //can be set by script at @dclick, butte also checks distance later. 5-6 min-max
             }
             break;
         }

--- a/src/game/clients/CClientEvent.cpp
+++ b/src/game/clients/CClientEvent.cpp
@@ -1532,14 +1532,14 @@ void CClient::Event_VendorSell(CChar* pVendor, const VendorItem* items, uint uiI
 		if ( amount >= pItem->GetAmount())
 		{
 			pItem->RemoveFromView();
-			if ( pVendor->IsStatFlag(STATF_PET) && pContExtra )
+			if ( pContExtra )
 				pContExtra->ContentAdd(pItem);
 			else
 				pItem->Delete();
 		}
 		else
 		{
-			if ( pVendor->IsStatFlag(STATF_PET) && pContExtra )
+			if ( pContExtra )
 			{
 				CItem * pItemNew = CItem::CreateDupeItem(pItem);
 				pItemNew->SetAmount(amount);


### PR DESCRIPTION
Non tested yet so this isnt a real Pull Request, I`ll start testing when I have a bunch of fixes, but if anyone is interested in accelerate the proccess, just compile my fork and test it. Dont forget feedback.
Here I will update fixes updated in my fork and can discuss about the fixes.

FIXES:
-Allow vendors use layer_special and keep bought items until next restock. 
-Prevent horses from being killed while ridden. (z=127)
-Fix and unchain archery butter to be used with any weapon with flag SKF_RANGED at 16 tiles max. (only works at 5-6 or if u are close enought to grab ammo.
-Command "Sleep" will wake up chars who already are sleeping.
-Rideable death horses fix.

