### PR TITLE
Fix: Vendors dont keep bought items

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -3035,3 +3035,5 @@ Note: The only way the server has to know if the bankself is closed is to store 
 - Fixed: Removing a secured container from a multi didn't work. (Issue #685)
 - Fixed: Moving multis now will add components as first priority to avoid dropping them. (Issue #821)
 - Changed: Skills with SKF_GATHER, @Start/@SkillStart, now ACT is the Worldgem Bit we're gathering from.
+
+20-09-2022

--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -3037,3 +3037,4 @@ Note: The only way the server has to know if the bankself is closed is to store 
 - Changed: Skills with SKF_GATHER, @Start/@SkillStart, now ACT is the Worldgem Bit we're gathering from.
 
 20-09-2022
+Fixed: normal vendors not being able to keep bought items.

--- a/src/game/clients/CClientEvent.cpp
+++ b/src/game/clients/CClientEvent.cpp
@@ -1539,7 +1539,7 @@ void CClient::Event_VendorSell(CChar* pVendor, const VendorItem* items, uint uiI
 		}
 		else
 		{
-			if ( pVendor->IsStatFlag(STATF_PET) && pContExtra )
+			if ( pContExtra )
 			{
 				CItem * pItemNew = CItem::CreateDupeItem(pItem);
 				pItemNew->SetAmount(amount);


### PR DESCRIPTION
Only player's vendors were allow to keep bought items. As I dont see any issue about player's vendors using it, I just removed the check.