### PR TITLE
Fix Mounts ridden can't tick if damaged

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -3038,3 +3038,5 @@ Note: The only way the server has to know if the bankself is closed is to store 
 
 19-09-2022, Tolokio
 -Added: Wake() is now avaible to be used by script using command: "wake"
+
+-Fix: Mounts were not passing _CanTick check correctly if were damaged by anyone. Doing the mount inmortal until dismount.

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -284,7 +284,8 @@ void CChar::OnHarmedBy( CChar * pCharSrc )
 
 	bool fFightActive = Fight_IsActive();
 	Memory_AddObjTypes(pCharSrc, MEMORY_HARMEDBY);
-
+	if (Skill_GetActive() == NPCACT_RIDDEN)
+		return;
 	if (fFightActive && m_Fight_Targ_UID.CharFind())
 	{
 		// In war mode already
@@ -322,8 +323,6 @@ bool CChar::OnAttackedBy(CChar * pCharSrc, bool fCommandPet, bool fShouldReveal)
 		return true;	// self induced
 	if (IsStatFlag(STATF_DEAD|STATF_STONE))
 		return false;
-	if (IsStatFlag(STATF_RIDDEN))
-		return true;
 
 	if (fShouldReveal)
 		pCharSrc->Reveal();	// fix invis exploit

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -322,6 +322,8 @@ bool CChar::OnAttackedBy(CChar * pCharSrc, bool fCommandPet, bool fShouldReveal)
 		return true;	// self induced
 	if (IsStatFlag(STATF_DEAD|STATF_STONE))
 		return false;
+	if (IsStatFlag(STATF_RIDDEN))
+		return true;
 
 	if (fShouldReveal)
 		pCharSrc->Reveal();	// fix invis exploit


### PR DESCRIPTION

if anyone damaged a mount being ridden, it would stop any tick until dismount.