### PR TITLE
Fix: Mounts losin action 111 if damaged.

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -3038,3 +3038,9 @@ Note: The only way the server has to know if the bankself is closed is to store 
 
 19-09-2022, Tolokio
 -Added: Wake() is now avaible to be used by script using command: "wake"
+
+
+23-09-2022, Tolokio
+-Fix: Mounts losing action 111 when harmed by anyone.
+Now they dont try to fight back or desert if is hardmed by own master while being ridden.
+Mounts where unable to die or tick if action 111 were changed. Now seems ok.

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -284,7 +284,9 @@ void CChar::OnHarmedBy( CChar * pCharSrc )
 
 	bool fFightActive = Fight_IsActive();
 	Memory_AddObjTypes(pCharSrc, MEMORY_HARMEDBY);
-
+	
+	if (Skill_GetActive() == NPCACT_RIDDEN) //prevent action 111 to be changed.
+		return;
 	if (fFightActive && m_Fight_Targ_UID.CharFind())
 	{
 		// In war mode already


### PR DESCRIPTION
Damaging a ridden mount will set its action -1. This causes mounts to stop ticking.

Fix would just avoid: fighting back and dessert if were harmed by master.