### PR TITLE
Fix: Dismount when death or released.

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -3038,3 +3038,6 @@ Note: The only way the server has to know if the bankself is closed is to store 
 
 19-09-2022, Tolokio
 -Added: Wake() is now avaible to be used by script using command: "wake"
+
+23-09-2022, Tolokio
+-Fix: Mounts dosnt get dismounted when death or released.

--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -3149,7 +3149,8 @@ bool CChar::Death()
 	StatFlag_Set(STATF_DEAD);
 	StatFlag_Clear(STATF_STONE|STATF_FREEZE|STATF_HIDDEN|STATF_SLEEPING|STATF_HOVERING);
 	SetPoisonCure(true);
-	Skill_Cleanup();
+	if (Skill_GetActive() != NPCACT_RIDDEN)
+		Skill_Cleanup();
 	Spell_Dispel(100);		// get rid of all spell effects (moved here to prevent double @Destroy trigger)
 
 	if ( m_pPlayer )		// if I'm NPC then my mount goes with me

--- a/src/game/chars/CCharNPCPet.cpp
+++ b/src/game/chars/CCharNPCPet.cpp
@@ -860,7 +860,8 @@ void CChar::NPC_PetRelease()
 	}
 
 	SoundChar(CRESND_NOTICE);
-	Skill_Start(SKILL_NONE);
+	if (Skill_GetActive() != NPCACT_RIDDEN)
+		Skill_Start(SKILL_NONE);
 	NPC_PetClearOwners();
 	UpdatePropertyFlag();
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20745578/191997037-01d64a7e-2846-4fc5-b36d-cb8892896c5b.png)

That checks never happens. When it reach that part, action is no longer NPCACT_RIDDEN.

Notes:
-This fix allow unmount if mount dies or get released. As it was pretended I think.
-This fix will cause people dismounted due mount dosnt have enought food and release.
-This may cause npc losing mounts? Non tested.