### PR TITLE
Fix Not dismounting if pet_release() or death()

### DIFF
--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -3038,3 +3038,7 @@ Note: The only way the server has to know if the bankself is closed is to store 
 
 19-09-2022, Tolokio
 -Added: Wake() is now avaible to be used by script using command: "wake"
+
+23-09-2022, Tolokio
+-Fix: death and dessert of ridden npcs now dismount npcs.
+

--- a/Changelog-X1-Nightlies.txt
+++ b/Changelog-X1-Nightlies.txt
@@ -3040,5 +3040,5 @@ Note: The only way the server has to know if the bankself is closed is to store 
 -Added: Wake() is now avaible to be used by script using command: "wake"
 
 23-09-2022, Tolokio
--Fix: death and dessert of ridden npcs now dismount npcs.
+-Fix: death and dessert of ridden npcs now dismount rider.
 

--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -3088,11 +3088,14 @@ bool CChar::Death()
 			return true;
 	}
 	//Dismount now. Later is too late. death will remove npc and the body will appear where it was mounted for last time.
-	if (Skill_GetActive() == NPCACT_RIDDEN) 
+	if ( m_pNPC )
 	{
-		CChar* pCRider = Horse_GetMountChar();
-		if (pCRider)
-			pCRider->Horse_UnMount();
+		if (Skill_GetActive() == NPCACT_RIDDEN) 
+		{
+			CChar* pCRider = Horse_GetMountChar();
+			if (pCRider)
+				pCRider->Horse_UnMount();
+		}
 	}
 	// Look through memories of who I was fighting (make sure they knew they where fighting me)
 	for (CSObjContRec* pObjRec : GetIterationSafeContReverse())

--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -3087,7 +3087,13 @@ bool CChar::Death()
 		if ( OnTrigger(CTRIG_Death, this) == TRIGRET_RET_TRUE )
 			return true;
 	}
-
+	//Dismount now. Later is too late. death will remove npc and the body will appear where it was mounted for last time.
+	if (Skill_GetActive() == NPCACT_RIDDEN) 
+	{
+		CChar* pCRider = Horse_GetMountChar();
+		if (pCRider)
+			pCRider->Horse_UnMount();
+	}
 	// Look through memories of who I was fighting (make sure they knew they where fighting me)
 	for (CSObjContRec* pObjRec : GetIterationSafeContReverse())
 	{

--- a/src/game/chars/CCharNPCPet.cpp
+++ b/src/game/chars/CCharNPCPet.cpp
@@ -859,8 +859,9 @@ void CChar::NPC_PetRelease()
 		return;
 	}
 
-	SoundChar(CRESND_NOTICE);
-	Skill_Start(SKILL_NONE);
+	SoundChar(CRESND_NOTICE); 
+	if (Skill_GetActive() != NPCACT_RIDDEN)
+		Skill_Start(SKILL_NONE);
 	NPC_PetClearOwners();
 	UpdatePropertyFlag();
 }


### PR DESCRIPTION
This fix makes mounts dismount their riders if mount dies or get released some how. (note this fix needs a related fix to properly work: https://github.com/Sphereserver/Source-X/pull/905

Reason for this fix: if mounts dies, Char needs to be dismounted before corpse is created or it will glitch.
 There are others ways to achieve it but I think this is the best method. (At least for me)

known issues:
-Mount dosnt show death animation (falling anim) when it dies, it just appear dead on the floor wihout any anim. 


To avoid getting dismounted if pet desserts or dies while being ridden, just:
```
@death/pet_dessert
if <flags>&statf_ridden
return 1
endif
```