### PR TITLE
Feature/update GitHub workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        name: ${{ github.sha }}
+        name: Builds
         path: SphereSvrX-win64-nightly.zip
 
     # only create nightly release if the branch is main
@@ -65,7 +65,7 @@ jobs:
       env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        name: ${{ github.sha }}
+        name: Builds
         path: SphereSvrX-win32-nightly.zip
 
     # only create nightly release if the branch is main
@@ -105,7 +105,7 @@ jobs:
       env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        name: ${{ github.sha }}
+        name: Builds
         path: SphereSvrX-linux64-nightly.tar.gz
 
     # only create nightly release if the branch is main
@@ -146,7 +146,7 @@ jobs:
       env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        name: ${{ github.sha }}
+        name: Builds
         path: SphereSvrX-linux32-nightly.tar.gz
     
     # only create nightly release if the branch is main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
 
     # only create nightly release if the branch is main
     - name: Create pull request tag and upload files
-      if: ${{ github.ref_name == 'main' }}
+      if: contains(fromJson('["master", "main"]'), github.ref_name)
       uses: softprops/action-gh-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -70,7 +70,7 @@ jobs:
 
     # only create nightly release if the branch is main
     - name: Create pull request tag and upload files
-      if: ${{ github.ref_name == 'main' }}
+      if: contains(fromJson('["master", "main"]'), github.ref_name)
       uses: softprops/action-gh-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -110,7 +110,7 @@ jobs:
 
     # only create nightly release if the branch is main
     - name: Create pull request tag and upload files
-      if: ${{ github.ref_name == 'main' }}
+      if: contains(fromJson('["master", "main"]'), github.ref_name)
       uses: softprops/action-gh-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -151,7 +151,7 @@ jobs:
     
     # only create nightly release if the branch is main
     - name: Create pull request tag and upload files
-      if: ${{ github.ref_name == 'main' }}
+      if: contains(fromJson('["master", "main"]'), github.ref_name)
       uses: softprops/action-gh-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,11 @@
-name: Pull request build
+name: Build
 
-on: [pull_request]
+on:
+  - push
+  - pull_request
 
 jobs:
   windows-64:
-
     runs-on: windows-latest
 
     steps:
@@ -19,18 +20,29 @@ jobs:
       run: |
             mkdir accounts, logs, save, scripts
             7z a SphereSvrX-win64-nightly.zip accounts\ logs\ save\ scripts\ .\bin64\Nightly\SphereSvrX64_nightly.exe .\src\sphere.ini .\src\sphereCrypt.ini .\dlls\64\libmysql.dll
-    - name: Create pull request tag and upload files
-      id: create_release
-      uses: softprops/action-gh-release@v1
+
+    # only upload artifact is pull request
+    - name: Upload artifact
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/upload-artifact@v3
       env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-          name: PR-${{ github.ref_name }}
-          tag_name: PR-${{ github.ref_name }}
+        name: ${{ github.sha }}
+        path: SphereSvrX-win64-nightly.zip
+
+    # only create nightly release if the branch is main
+    - name: Create pull request tag and upload files
+      if: ${{ github.ref_name == 'main' }}
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+          name: Nightly
+          tag_name: Nightly
           files: SphereSvrX-win64-nightly.zip
 
   windows-32:
-
     runs-on: windows-latest
 
     steps:
@@ -45,18 +57,29 @@ jobs:
       run:  |
             mkdir accounts, logs, save, scripts
             7z a SphereSvrX-win32-nightly.zip accounts\ logs\ save\ scripts\ .\bin\Nightly\SphereSvrX32_nightly.exe .\src\sphere.ini .\src\sphereCrypt.ini .\dlls\32\libmysql.dll
-    - name: Create pull request tag and upload files
-      id: create_release
-      uses: softprops/action-gh-release@v1
+
+    # only upload artifact is pull request
+    - name: Upload artifact
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/upload-artifact@v3
       env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-          name: PR-${{ github.ref_name }}
-          tag_name: PR-${{ github.ref_name }}
+        name: ${{ github.sha }}
+        path: SphereSvrX-win32-nightly.zip
+
+    # only create nightly release if the branch is main
+    - name: Create pull request tag and upload files
+      if: ${{ github.ref_name == 'main' }}
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+          name: Nightly
+          tag_name: Nightly
           files: SphereSvrX-win32-nightly.zip
 
   linux-64:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -74,18 +97,29 @@ jobs:
       run:  |
             mkdir accounts logs save scripts
             tar -czf SphereSvrX-linux64-nightly.tar.gz accounts/ logs/ save/ scripts/ -C bin64/ SphereSvrX64_nightly -C ../src/ sphere.ini sphereCrypt.ini
-    - name: Create pull request tag and upload files
-      id: create_release
-      uses: softprops/action-gh-release@v1
+
+    # only upload artifact is pull request
+    - name: Upload artifact
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/upload-artifact@v3
       env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-          name: PR-${{ github.ref_name }}
-          tag_name: PR-${{ github.ref_name }}
+        name: ${{ github.sha }}
+        path: SphereSvrX-linux64-nightly.tar.gz
+
+    # only create nightly release if the branch is main
+    - name: Create pull request tag and upload files
+      if: ${{ github.ref_name == 'main' }}
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+          name: Nightly
+          tag_name: Nightly
           files: SphereSvrX-linux64-nightly.tar.gz
 
   linux-32:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -104,12 +138,24 @@ jobs:
       run:  |
             mkdir accounts logs save scripts
             tar -czf SphereSvrX-linux32-nightly.tar.gz accounts/ logs/ save/ scripts/ -C bin/ SphereSvrX32_nightly -C ../src/ sphere.ini sphereCrypt.ini
-    - name: Create pull request tag and upload files
-      id: create_release
-      uses: softprops/action-gh-release@v1
+
+    # only upload artifact is pull request
+    - name: Upload artifact
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/upload-artifact@v3
       env:
          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-          name: PR-${{ github.ref_name }}
-          tag_name: PR-${{ github.ref_name }}
+        name: ${{ github.sha }}
+        path: SphereSvrX-linux32-nightly.tar.gz
+    
+    # only create nightly release if the branch is main
+    - name: Create pull request tag and upload files
+      if: ${{ github.ref_name == 'main' }}
+      uses: softprops/action-gh-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+          name: Nightly
+          tag_name: Nightly
           files: SphereSvrX-linux32-nightly.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,35 @@
-# Ignore all files, except those already included on git repository
-/*
+# Ignore folder and files
+/bin
+/bin64
+/Debug
+/Release
+/Nightly
+/backup/
+/.git/
+/.vscode/
+/x64/
+/x86/
+/obj/
+/build/
+/mul
+/accounts/
+/logs/
+/save/
+/web/
+
+*.vs
+*.pid
+
+# Ignore files
+*.bak
+*.log
+*.old
+*.tmp
+*.o
+*.obj
+*.exe
+*.vcxproj.*
+
+# Ignore git versioning file
 /src/common/version/GitRevision.h
 /src/common/libev/config.h
-
-!.github


### PR DESCRIPTION
#915 

Update gitignore
Update github workflow, now every time we do a push, the workflow will launch a build to compile and see that nothing is broken.
When a pull request is created, if the compilation is successful, an artifact is generated with the project binaries to be able to test it.
Each time a push is made on the main/master branch a new nightly build is generated and a new tag is generated.

P.D: Maybe for upload artifacts or create release, need to check that the workflows have write permissions: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository