### PR TITLE
Fix: Deleting a player while it's in a guild cause the server to crash. (Issue #971).

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3095,3 +3095,6 @@ Notes:
 - Changed: The DAM property (for both characters and weapons) can be displayed up to 65k. (Issue #967)
 - Added: t_armor_bone typedef (value 305). If you want to use it you need to add it in the core/defs_types_hardcoded.scp file under the typedef section. (Issue #890)
 		
+03-12-2022, Drk84
+03-12-2022, Drk84
+- Fix: Deleting a player while it's in a guild cause the server to crash. (Issue #971).

--- a/src/game/chars/CChar.cpp
+++ b/src/game/chars/CChar.cpp
@@ -342,8 +342,8 @@ CChar::~CChar()
         m_pParty->RemoveMember( GetUID(), GetUID() );
         m_pParty = nullptr;
     }
-    Guild_Resign(MEMORY_GUILD);
-    Guild_Resign(MEMORY_TOWN);
+    //Guild_Resign(MEMORY_GUILD); Moved to the ClearPlayer method otherwise it will cause a server crash because the deleted player will still be found in the guild list.
+    //Guild_Resign(MEMORY_TOWN);  Moved to the ClearPlayer method otherwise it will cause a server crash because the deleted player will still be found in the guild list.
     Attacker_RemoveChar();		// Removing me from enemy's attacker list (I asume that if he is on my list, I'm on his one and no one have me on their list if I dont have them)
     if (m_pNPC)
         NPC_PetClearOwners();	// Clear follower slots on pet owner
@@ -563,7 +563,8 @@ void CChar::ClearPlayer()
 
 		pAccount->DetachChar(this);	// unlink me from my account.
 	}
-    
+	Guild_Resign(MEMORY_GUILD);
+	Guild_Resign(MEMORY_TOWN);
     delete m_pPlayer;
     m_pPlayer = nullptr;
 }


### PR DESCRIPTION


When a player is deleted the ClearPlayer method is called and this set the m_pPlayer property to null. When a deleted player is inside a guild, the Guild_Resign method will fail because this method relies upon the m_pPlayer to succeed (and the destructor is called after ClearPlayer).

So i just moved the Guild_Resign method in the ClearPlayer before the m_pPlayer property is set to null.

