### PR TITLE
[Sphere.ini] Added: New Sphere.ini settings "DisplayElementalResistance". (Issue #742) 

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3072,9 +3072,9 @@ Notes:
 
 22-10-2022, Drk84
 - Fixed: PARTY.CREATE would make the invited player inviting himself..
-		The command syntaxis: PARTY.CREATE msg,uid(s).
-		Where msg is 0/1 sending default sysmessages or not, the following args (up to 9 more) is/are the players to add to this party.
-		Note that by using PARTY.CREATE the player will be forced to enter the party, so you need to add your own "acceptance system".
+		 The command syntaxis: PARTY.CREATE msg,uid(s).
+		 Where msg is 0/1 sending default sysmessages or not, the following args (up to 9 more) is/are the players to add to this party.
+		 Note that by using PARTY.CREATE the player will be forced to enter the party, so you need to add your own "acceptance system".
 		
 24-10-2022, Raylde/Jhobean
 [sphere.ini]: Added TimerCallUnit to be able use seconds instead of minutes with TimerCall
@@ -3096,5 +3096,9 @@ Notes:
 - Added: t_armor_bone typedef (value 305). If you want to use it you need to add it in the core/defs_types_hardcoded.scp file under the typedef section. (Issue #890)
 		
 03-12-2022, Drk84
-03-12-2022, Drk84
-- Fix: Deleting a player while it's in a guild cause the server to crash. (Issue #971).
+- Fix: Deleting a player while it's in a guild cause the server to crash. (Issue #971)
+
+06-12-2022, Drk84
+- [Sphere.ini] Added: New Sphere.ini settings "DisplayElementalResistance". (Issue #742) 
+					  This setting allows to display the elemental resistances (Fire, Cold, Energy, Poison but not Physical) on status bar and tooltips, even if combat flag ELEMENTAL_ENGINE is disabled.
+					  Remember that the old AC(and MODAR) system will be used if ELEMENTAL_ENGINE flag is disabled.

--- a/src/game/CServerConfig.cpp
+++ b/src/game/CServerConfig.cpp
@@ -182,6 +182,7 @@ CServerConfig::CServerConfig()
 	m_iRevealFlags			= (REVEALF_DETECTINGHIDDEN|REVEALF_LOOTINGSELF|REVEALF_LOOTINGOTHERS|REVEALF_SPEAK|REVEALF_SPELLCAST);
 	m_iEmoteFlags			= 0;
 	m_fDisplayPercentAr = false;
+	m_fDisplayElementalResistance = false;
 	m_fNoResRobe		= 0;
 	m_iLostNPCTeleport	= 50;
 	m_iAutoProcessPriority = 0;
@@ -496,6 +497,7 @@ enum RC_TYPE
 	RC_DECAYTIMER,
 	RC_DEFAULTCOMMANDLEVEL,		//m_iDefaultCommandLevel
 	RC_DISPLAYPERCENTAR,	    //m_fDisplayPercentAr
+	RC_DISPLAYELEMENTALRESISTANCE, //m_fDisplayElementalResistance
 	RC_DISTANCETALK,
 	RC_DISTANCEWHISPER,
 	RC_DISTANCEYELL,
@@ -761,6 +763,7 @@ const CAssocReg CServerConfig::sm_szLoadKeys[RC_QTY+1] =
 	{ "DECAYTIMER",				{ ELEM_INT,		OFFSETOF(CServerConfig,m_iDecay_Item)			}},
 	{ "DEFAULTCOMMANDLEVEL",	{ ELEM_INT,		OFFSETOF(CServerConfig,m_iDefaultCommandLevel)	}},
 	{ "DISPLAYARMORASPERCENT",  { ELEM_BOOL,    OFFSETOF(CServerConfig,m_fDisplayPercentAr)		}},
+	{ "DISPLAYELEMENTALRESISTANCE",{ELEM_BOOL,	OFFSETOF(CServerConfig,m_fDisplayElementalResistance)}},
 	{ "DISTANCETALK",			{ ELEM_INT,		OFFSETOF(CServerConfig,m_iDistanceTalk )		}},
 	{ "DISTANCEWHISPER",		{ ELEM_INT,		OFFSETOF(CServerConfig,m_iDistanceWhisper )		}},
 	{ "DISTANCEYELL",			{ ELEM_INT,		OFFSETOF(CServerConfig,m_iDistanceYell )		}},

--- a/src/game/CServerConfig.h
+++ b/src/game/CServerConfig.h
@@ -348,8 +348,9 @@ public:
 	int  m_iSkillPracticeMax;		// max skill level a player can practice on dummies/targets upto.
 	bool m_iPacketDeathAnimation;	// packet 02c
     bool m_fDisplayPercentAr;       // Display the ARMOR value in the tooltip as the % 
-
-	// Flags for controlling pvp/pvm behaviour of players
+    bool m_fDisplayElementalResistance; //Display the Elemental and MAxElemental Resistances on the paperdoll and tooltips (RESFIRE/RESCOLD/RESENERGY/RESPOISON) even if combat flag Elemental Engine is disabled.
+	
+    // Flags for controlling pvp/pvm behaviour of players
 	uint m_iCombatFlags;   // combat flags
 	uint m_iMagicFlags;    // magic flags
 	uint m_iRacialFlags;   // racial traits flags

--- a/src/game/components/CCPropsChar.cpp
+++ b/src/game/components/CCPropsChar.cpp
@@ -145,7 +145,7 @@ void CCPropsChar::SetPropertyNum(PropertyIndex_t iPropIndex, PropertyValNum_t iV
         {
             // This should be used in case items with these properties updates the character in the moment without any script to make status reflect the update.
             // Maybe too a cliver check to not send update if not needed.
-            if (IsSetCombatFlags(COMBAT_ELEMENTAL_ENGINE))
+            if (IsSetCombatFlags(COMBAT_ELEMENTAL_ENGINE) || g_Cfg.m_fDisplayElementalResistance)
             {
                 CChar * pChar = static_cast <CChar*>(pLinkedObj);
                 pChar->UpdateStatsFlag();

--- a/src/game/components/CCPropsItemEquippable.cpp
+++ b/src/game/components/CCPropsItemEquippable.cpp
@@ -487,7 +487,7 @@ void CCPropsItemEquippable::AddPropsTooltipData(CObjBase* pLinkedObj)
                 // Missing cliloc id? (doesn't exist)
                 break;
             case PROPIEQUIP_RESCOLD:
-                if (IsSetCombatFlags(COMBAT_ELEMENTAL_ENGINE))
+                if (g_Cfg.m_fDisplayElementalResistance)
                     ADDTNUM(1060445); // cold resist ~1_val~%
                 break;
             case PROPIEQUIP_RESCOLDMAX: // Unimplemented
@@ -495,7 +495,7 @@ void CCPropsItemEquippable::AddPropsTooltipData(CObjBase* pLinkedObj)
                     //Missing cliloc id
                 break;
             case PROPIEQUIP_RESENERGY:
-                if (IsSetCombatFlags(COMBAT_ELEMENTAL_ENGINE))
+                if (g_Cfg.m_fDisplayElementalResistance)
                     ADDTNUM(1060446); // energy resist ~1_val~%
                 break;
             case PROPIEQUIP_RESENERGYMAX: // Unimplemented
@@ -503,7 +503,7 @@ void CCPropsItemEquippable::AddPropsTooltipData(CObjBase* pLinkedObj)
                     //Missing cliloc id
                 break;
             case PROPIEQUIP_RESFIRE:
-                if (IsSetCombatFlags(COMBAT_ELEMENTAL_ENGINE))
+                if (g_Cfg.m_fDisplayElementalResistance)
                     ADDTNUM(1060447); // fire resist ~1_val~%
                 break;
             case PROPIEQUIP_RESFIREMAX: // Unimplemented
@@ -539,7 +539,7 @@ void CCPropsItemEquippable::AddPropsTooltipData(CObjBase* pLinkedObj)
                     //Missing cliloc id
                 break;
             case PROPIEQUIP_RESPOISON:
-                if (IsSetCombatFlags(COMBAT_ELEMENTAL_ENGINE))
+                if (g_Cfg.m_fDisplayElementalResistance)
                     ADDTNUM(1060449); // poison resist ~1_val~%
                 break;
             case PROPIEQUIP_RESPOISONMAX: // Unimplemented

--- a/src/network/send.cpp
+++ b/src/network/send.cpp
@@ -292,7 +292,7 @@ void PacketObjectStatus::WriteVersionSpecific(const CClient* target, CChar* othe
 
 	if (version >= 4) // AOS attributes
 	{
-        if (fElemental)
+        if (fElemental || g_Cfg.m_fDisplayElementalResistance)
         {
             writeInt16((word)other->GetPropNum(pCCPChar,     PROPCH_RESFIRE, pBaseCCPChar));
             writeInt16((word)other->GetPropNum(pCCPChar,     PROPCH_RESCOLD, pBaseCCPChar));
@@ -314,7 +314,7 @@ void PacketObjectStatus::WriteVersionSpecific(const CClient* target, CChar* othe
 
 	if (version >= 6)	// SA attributes
 	{
-        if (fElemental)
+        if (fElemental || g_Cfg.m_fDisplayElementalResistance)
         {
             writeInt16((word)other->GetPropNum(pCCPChar,     PROPCH_RESPHYSICALMAX, pBaseCCPChar));
             writeInt16((word)other->GetPropNum(pCCPChar,     PROPCH_RESFIREMAX, pBaseCCPChar));

--- a/src/sphere.ini
+++ b/src/sphere.ini
@@ -424,6 +424,9 @@ CombatParryingEra=01|010
 //When enabled, display, in the tooltip, the Armor of the item as a percentage of its full armor value, the percentage is based  upon the body parts the item covers.
 DisplayArmorAsPercent = 0
 
+//When enabled, display, in the status bar the elemental (and the max elemental) resistances even if the combat flag ELEMENTAL ENGINE is disabled.
+DisplayElementalResistance = 0
+
 // Extra magic flags to control magic/magery behaviour (default:0, 0.55i compatible)
 // MAGICF_NODIRCHANGE           00001	// Not rotate player when casting/targeting
 // MAGICF_PRECAST               00002	// Precasting (cast spell before target prompt)


### PR DESCRIPTION
This setting allows to display the elemental resistances (Fire, Cold, Energy, Poison but not Physical) on status bar and tooltips, even if combat flag ELEMENTAL_ENGINE is disabled.
Remember that the old AC(and MODAR) system will be used if ELEMENTAL_ENGINE flag is disabled.