### PR TITLE
Deleting a multi would not call the @Destroy trigger. (Issue #988)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3112,3 +3112,6 @@ Fixed: @Ship_Turn not firing, this trigger will fire on a T_SHIP item and for ev
 
 15-12-2022, Drk84
 Fixed(Maybe): Fix for Attack speed exploit with COMBAT_FIRSTHIT_INSTANT. (Issue #790)
+
+24-12-2022, Drk84
+Fixed: Multi type items weren't calling the @Destroy triggers when removed. (Issue #988)

--- a/src/game/items/CItemMulti.cpp
+++ b/src/game/items/CItemMulti.cpp
@@ -143,7 +143,8 @@ bool CItemMulti::Delete(bool fForce)
             pMultiStorage->DelMulti(GetUID());
     }
    
-    return CObjBase::Delete(fForce);
+    //return CObjBase::Delete(fForce);
+    return CItem::Delete(fForce);
 }
 
 const CItemBaseMulti * CItemMulti::Multi_GetDef() const noexcept


### PR DESCRIPTION
It seems that CObBase::Delete (Virtual) was called instead of CItem::Delete ( don't know why)