### PR TITLE
- Added [Sphere.ini]: New Sphere.ini settings "NPCHealTreshold", this…

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3099,7 +3099,7 @@ Notes:
 - Fix: Deleting a player while it's in a guild cause the server to crash. (Issue #971)
 
 06-12-2022, Drk84
-- [Sphere.ini] Added: New Sphere.ini settings "DisplayElementalResistance". (Issue #742) 
+- Added [Sphere.ini] : New Sphere.ini settings "DisplayElementalResistance". (Issue #742) 
 			   This setting allows to display the elemental resistances (Fire, Cold, Energy, Poison but not Physical) on status bar and tooltips, even if combat flag ELEMENTAL_ENGINE is disabled.
 			   Remember that the old AC(and MODAR) system will be used if ELEMENTAL_ENGINE flag is disabled.
 
@@ -3141,7 +3141,7 @@ Fixed: Multi type items weren't calling the @Destroy triggers when removed. (Iss
 		 ON=@Hit
 		 argn1 = <R<damadjusted>> //This recalculates the full damage including the various bonus if any.
 		
-01-12-2022, Drk84
+01-12-2023, Drk84
 - Added: New trigger @NpcActCast, this trigger is fired when an NPC is going to select which spell is going to cast.
 		 This triggers can fires multiple time if the NPC cannot cast the selected spell (for example because the spell has the SPELLFLAG_PLAYERONLY flag).
 		 So always make sure your casting NPCs has a proper spell selection, so try to avoid giving them full spellbooks because more than half spells in there has the SPELLFLAG_PLAYERONLY flag.
@@ -3157,3 +3157,7 @@ Fixed: Multi type items weren't calling the @Destroy triggers when removed. (Iss
 			 Return 1: Interrupt spell selection.
 - Changed: If the NPC is wielding a wand, it has a 50% to use the wand instead of the a spell from the spellbook11. Remember that the wand must have the ATTR_MAGIC set.
 - Fixed: Bonus from CombatBonusStat, when the stat was above 100, was not properly applied when COMBAT_DAMAGEERA was set to 2 (AOS)    
+
+02-01-2023, Drk84
+- Added [Sphere.ini]: New Sphere.ini settings "NPCHealTreshold", this setting determines the amount of target hitpoints (in %) at which a NPC will try to heal by spell.
+- Added: New local "local.healtreshold" in the @NpcActCast trigger, this setting determines the amount of target hitpoints (in %) at which a NPC will try to heal by spell.

--- a/src/game/CServerConfig.cpp
+++ b/src/game/CServerConfig.cpp
@@ -55,6 +55,7 @@ CServerConfig::CServerConfig()
     m_fManaLossFail		    = false;
 	m_fManaLossPercent		= 50;
 	m_fNPCCanFizzleOnHit	= false;
+	m_iNPCHealtreshold = 30;
 	m_fReagentLossAbort		= false;
 	m_fReagentLossFail		= false;
     m_fReagentsRequired		= false;
@@ -610,6 +611,7 @@ enum RC_TYPE
 	RC_NPCAI,					// m_iNpcAi
 	RC_NPCCANFIZZLEONHIT,		// m_fNPCCanFizzle
     RC_NPCDISTANCEHEAR,         // m_iNPCDistanceHear
+	RC_NPCHEALTRESHOLD,			// m_iNPCHealtreshold
 	RC_NPCNOFAMETITLE,			// m_NPCNoFameTitle
 	RC_NPCSHOVENPC,				// m_NPCShoveNPC
 	RC_NPCSKILLSAVE,			// m_iSaveNPCSkills
@@ -876,6 +878,7 @@ const CAssocReg CServerConfig::sm_szLoadKeys[RC_QTY+1] =
 	{ "NPCAI",					{ ELEM_INT,		OFFSETOF(CServerConfig,m_iNpcAi)				}},
 	{ "NPCCANFIZZLEONHIT",		{ ELEM_BOOL,	OFFSETOF(CServerConfig,m_fNPCCanFizzleOnHit)	}},
     { "NPCDISTANCEHEAR",        { ELEM_INT,     OFFSETOF(CServerConfig,m_iNPCDistanceHear)		}},
+	{ "NPCHEALTRESHOLD",        { ELEM_INT,     OFFSETOF(CServerConfig,m_iNPCHealtreshold)      }},
 	{ "NPCNOFAMETITLE",			{ ELEM_BOOL,	OFFSETOF(CServerConfig,m_NPCNoFameTitle)		}},
 	{ "NPCSHOVENPC",			{ ELEM_BOOL,	OFFSETOF(CServerConfig,m_NPCShoveNPC)			}},
 	{ "NPCSKILLSAVE",			{ ELEM_INT,		OFFSETOF(CServerConfig,m_iSaveNPCSkills)		}},

--- a/src/game/CServerConfig.h
+++ b/src/game/CServerConfig.h
@@ -284,6 +284,7 @@ public:
     bool m_fManaLossFail;       // Lose mana when spell casting failed.
     int  m_fManaLossPercent;    // Percent of mana loss when missing a cast
     bool m_fNPCCanFizzleOnHit;  // NPCs can fizzle the spell when hit in combat.
+    int m_iNPCHealtreshold;    // Minimum value in percent at which the NPCs will start to heal themselves with a spell.
     bool m_fReagentLossAbort;   // Lose reagents when spell casting abort.
 	bool m_fReagentLossFail;    // Lose reagents when spell casting failed.
 	int  m_iMagicUnlockDoor;    // 1 in N chance of magic unlock working on doors -- 0 means never.

--- a/src/game/chars/CChar.h
+++ b/src/game/chars/CChar.h
@@ -1243,7 +1243,7 @@ private:
 	int  NPC_WalkToPoint(bool fRun = false);
 	CChar * NPC_FightFindBestTarget();
 	bool NPC_FightMagery(CChar * pChar);
-	bool NPC_FightCast(CObjBase * &pChar ,CObjBase * pSrc, SPELL_TYPE &spell, int &skill);
+	bool NPC_FightCast(CObjBase * &pChar ,CObjBase * pSrc, SPELL_TYPE &spell, int &skill, int iHealTreshold, bool bIgnoreAITargetChoice = false);
 	bool NPC_FightArchery( CChar * pChar );
 	bool NPC_FightMayCast(bool fCheckSkill = true) const;
 	void NPC_GetAllSpellbookSpells();

--- a/src/sphere.ini
+++ b/src/sphere.ini
@@ -949,6 +949,9 @@ ManaLossPercent=50	// Percent of mana lost if cast fail/abort (0-100)
 // NPCs can fizzle the spell when hit in combat.
 NPCCanFizzleOnHit=0
 
+//This setting determines the amount of target hitpoints (in %) at which a NPC will try to heal by spell.
+NPCHealTreshold = 30
+
 // Reagents or tithing points lost if magic fails.
 ReagentLossAbort=0	// When spell is abort during casting
 ReagentLossFail=0	// When spell fizzle because of lacking skill


### PR DESCRIPTION
… setting determines the amount of target hitpoints (in %) at which a NPC will try to heal by spell.

- Added: New local "local.healtreshold" in the @NpcActCast trigger, this setting determines the amount of target hitpoints (in %) at which a NPC will try to heal by spell.