### PR TITLE
Fix chv_kill

### DIFF
--- a/src/game/chars/CChar.cpp
+++ b/src/game/chars/CChar.cpp
@@ -4291,7 +4291,7 @@ bool CChar::r_Verb( CScript &s, CTextConsole * pSrc ) // Execute command from sc
 		case CHV_KILL:
 			{
 				Effect( EFFECT_LIGHTNING, ITEMID_NOTHING, pCharSrc );
-				OnTakeDamage( 10000, pCharSrc, DAMAGE_GOD );
+				//OnTakeDamage( 10000, pCharSrc, DAMAGE_GOD );
 				Stat_SetVal( STAT_STR, 0 );
 				g_Log.Event( LOGL_EVENT|LOGM_KILLS|LOGM_GM_CMDS, "'%s' was KILLed by '%s'\n", GetName(), pSrc->GetName());
 			}


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/20745578/213177342-71d60df4-0b97-4924-8519-010a5fcc4e5a.png)


I think it is not neccesary to do damage through combat @triggers. It shows emote like: "xxx is attacking gamemaster" sysmessage ->"xxx were killed by GM/server"

There were a bug related to mounts that were hidden when u tested it using ".kill"

The only good thing that probably is the reason it stays like that, is that the damage output is played at player's head.
There is no sendpacket for that?

I think we could remove the damage part and just use sendpackets to show the damage over the char if it is possible. And if not, I prefer to just remove the damage part.

