### PR TITLE
Fix for Issue #1043 and Issue #1044 and local.spell for @gethit

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3226,3 +3226,9 @@ Fixed: Multi type items weren't calling the @Destroy triggers when removed. (Iss
 
 20-02-2023, Drk84
 -(Cheap) Fixed: Spawn Keyword AT.n.xx not working properly. (Issue #1033) 
+
+27-02-2023, Drk84
+- Fixed: Wrong duration for Gate Travel Spell. (Issue #1043)
+- Fixed: More accurate messages when a container/hold is locked and you have/don't have the key. (Issue #1044)
+- Added: New local in the @GetHit trigger: 
+		 LOCAL.SPELL: Read Only, display  the spell number that damaged the character. 

--- a/src/game/chars/CChar.h
+++ b/src/game/chars/CChar.h
@@ -1297,7 +1297,7 @@ public:
 	bool OnTriggerSpeech(bool bIsPet, lpctstr pszText, CChar * pSrc, TALKMODE_TYPE & mode, HUE_TYPE wHue = HUE_DEFAULT);
 
 	// Outside events that occur to us.
-	int  OnTakeDamage( int iDmg, CChar * pSrc, DAMAGE_TYPE uType, int iDmgPhysical = 0, int iDmgFire = 0, int iDmgCold = 0, int iDmgPoison = 0, int iDmgEnergy = 0 );
+	int  OnTakeDamage( int iDmg, CChar * pSrc, DAMAGE_TYPE uType, int iDmgPhysical = 0, int iDmgFire = 0, int iDmgCold = 0, int iDmgPoison = 0, int iDmgEnergy = 0, SPELL_TYPE spell = SPELL_NONE );
 	void OnHarmedBy( CChar * pCharSrc );
 	bool OnAttackedBy( CChar * pCharSrc, bool fPetsCommand = false, bool fShouldReveal = true );
 

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -612,7 +612,7 @@ int CChar::CalcArmorDefense() const
 //  -1		= already dead / invalid target.
 //  0		= no damage.
 //  INT32_MAX	= killed.
-int CChar::OnTakeDamage( int iDmg, CChar * pSrc, DAMAGE_TYPE uType, int iDmgPhysical, int iDmgFire, int iDmgCold, int iDmgPoison, int iDmgEnergy )
+int CChar::OnTakeDamage( int iDmg, CChar * pSrc, DAMAGE_TYPE uType, int iDmgPhysical, int iDmgFire, int iDmgCold, int iDmgPoison, int iDmgEnergy, SPELL_TYPE spell)
 {
 	ADDTOCALLSTACK("CChar::OnTakeDamage");
 
@@ -678,7 +678,7 @@ effect_bounce:
 		if ( pBloodOath && pBloodOath->m_uidLink == pSrc->GetUID() && !(uType & DAMAGE_FIXED) && !g_Cfg.GetSpellDef(SPELL_Blood_Oath)->IsSpellType(SPELLFLAG_SCRIPTED))	// if DAMAGE_FIXED is set we are already receiving a reflected damage, so we must stop here to avoid an infinite loop.
 		{
 			iDmg += iDmg / 10;
-			pSrc->OnTakeDamage(iDmg * (100 - pBloodOath->m_itSpell.m_spelllevel) / 100, this, DAMAGE_MAGIC|DAMAGE_FIXED);
+			pSrc->OnTakeDamage(iDmg * (100 - pBloodOath->m_itSpell.m_spelllevel) / 100, this, DAMAGE_MAGIC|DAMAGE_FIXED,0,0,0,0,0,SPELL_Blood_Oath);
 		}
 	}
 
@@ -729,6 +729,7 @@ effect_bounce:
 	CScriptTriggerArgs Args( iDmg, uType, (int64)(0) );
 	Args.m_VarsLocal.SetNum("ItemDamageLayer", sm_ArmorDamageLayers[Calc_GetRandVal(CountOf(sm_ArmorDamageLayers))]);
 	Args.m_VarsLocal.SetNum("ItemDamageChance", 25);
+	Args.m_VarsLocal.SetNum("Spell", (int)spell);
 
 	if ( IsTrigUsed(TRIGGER_GETHIT) )
 	{
@@ -908,6 +909,7 @@ effect_bounce:
 				if ( GetTopDist3D(pSrc) < 2 )
 				{
 					CItem* pReactive = LayerFind(LAYER_SPELL_Reactive);
+					
 					if (pReactive)
 					{
 						int iReactiveDamage = (iDmg * pReactive->m_itSpell.m_PolyStr) / 100;
@@ -917,7 +919,7 @@ effect_bounce:
 						}
 
 						iDmg -= iReactiveDamage;
-						pSrc->OnTakeDamage(iReactiveDamage, this, (DAMAGE_TYPE)(DAMAGE_FIXED | DAMAGE_REACTIVE), iDmgPhysical, iDmgFire, iDmgCold, iDmgPoison, iDmgEnergy);
+						pSrc->OnTakeDamage(iReactiveDamage, this, (DAMAGE_TYPE)(DAMAGE_FIXED | DAMAGE_REACTIVE), iDmgPhysical, iDmgFire, iDmgCold, iDmgPoison, iDmgEnergy,(SPELL_TYPE)pReactive->m_itSpell.m_spell);
 						pSrc->Sound(0x1F1);
 						pSrc->Effect(EFFECT_OBJ, ITEMID_FX_CURSE_EFFECT, this, 10, 16);
 					}

--- a/src/game/chars/CCharSpell.cpp
+++ b/src/game/chars/CCharSpell.cpp
@@ -294,7 +294,7 @@ bool CChar::Spell_CreateGate(CPointMap ptDest, bool fCheckAntiMagic)
 
     const CSpellDef *pSpellDef = g_Cfg.GetSpellDef(SPELL_Gate_Travel);
     ASSERT(pSpellDef);
-    const int64 iDuration = pSpellDef->m_Duration.GetLinear(0) * MSECS_PER_SEC;
+    const int64 iDuration = pSpellDef->m_Duration.GetLinear(0) * MSECS_PER_TENTH;
 
     ptDest.m_z = GetFixZ(ptDest);
     ITEMID_TYPE idOrig, idDest;
@@ -1977,7 +1977,8 @@ bool CChar::Spell_Equip_OnTick( CItem * pItem )
 				(iDmgType & DAMAGE_FIRE) ? 100 : 0,
 				(iDmgType & DAMAGE_COLD) ? 100 : 0,
 				(iDmgType & DAMAGE_POISON) ? 100 : 0,
-				(iDmgType & DAMAGE_ENERGY) ? 100 : 0);
+				(iDmgType & DAMAGE_ENERGY) ? 100 : 0,
+				spell);
 		}
 	}
 	else if (pSpellDef->IsSpellType(SPELLFLAG_HEAL))
@@ -3703,7 +3704,7 @@ bool CChar::OnSpellEffect( SPELL_TYPE spell, CChar * pCharSrc, int iSkillLevel, 
 		else
 			iDmgPhysical = 100;
 
-		OnTakeDamage(iEffect, pCharSrc, iDmgType, iDmgPhysical, iDmgFire, iDmgCold, iDmgPoison, iDmgEnergy);
+		OnTakeDamage(iEffect, pCharSrc, iDmgType, iDmgPhysical, iDmgFire, iDmgCold, iDmgPoison, iDmgEnergy,spell);
 	}
 
 	switch ( spell )

--- a/src/game/clients/CClientUse.cpp
+++ b/src/game/clients/CClientUse.cpp
@@ -178,12 +178,34 @@ bool CClient::Cmd_Use_Item( CItem *pItem, bool fTestTouch, bool fScript )
 			return false;
 
 		case IT_CONTAINER_LOCKED:
-		case IT_SHIP_HOLD_LOCK:
-			if ( !m_pChar->GetPackSafe()->ContentFindKeyFor(pItem) )
+			SysMessageDefault(DEFMSG_ITEMUSE_LOCKED);
+			if (!m_pChar->GetPackSafe()->ContentFindKeyFor(pItem)) // I don't have the container key
 			{
 				SysMessageDefault(DEFMSG_ITEMUSE_LOCKED);
+				SysMessageDefault(DEFMSG_LOCK_CONT_NO_KEY);
+				if (!IsPriv(PRIV_GM))
+					return false;
+			}
+			else // I have the key but i need to use it to unlock the container.
+			{
+				SysMessageDefault(DEFMSG_LOCK_HAS_KEY); 
+				return false;
+			}
+			break;
+
+		case IT_SHIP_HOLD_LOCK:
+			SysMessageDefault(DEFMSG_ITEMUSE_LOCKED);
+			if ( !m_pChar->GetPackSafe()->ContentFindKeyFor(pItem) ) // I don't have the hold key
+			{
+				
+				SysMessageDefault(DEFMSG_LOCK_HOLD_NO_KEY);
 				if ( !IsPriv(PRIV_GM) )
 					return false;
+			}
+			else // I have the key but i need to use it to unlock the container.
+			{
+				SysMessageDefault(DEFMSG_LOCK_HAS_KEY);
+				return false;
 			}
 			break;
 


### PR DESCRIPTION
- Fixed: Wrong duration for Gate Travel Spell. (Issue #1043) 
- Fixed: More accurate messages when a container/hold is locked and you have/don't have the key. (Issue #1044)
- Added: New local in the @GetHit trigger:
   LOCAL.SPELL: Read Only, display  the spell number that damaged the character.