### PR TITLE
- (Partially) Fixed: Localized messages throwing errors in consol when the speaker is not visibile. Partially because i can't still display the speaker name in the journal if the hearer is dead and DeadCannotSeeLiving is set to 2. (Issue #1049)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3237,3 +3237,10 @@ Fixed: Multi type items weren't calling the @Destroy triggers when removed. (Iss
 - Fixed: Animation was played while out of range when COMBAT_SWING_NORANGE flag is enabled. (Issue #819)
 - Fixed: Spell duration was calculated two times when a spell was cast.
 - Added: REPAIRPERCENT command used to display the current health of the item in %.
+
+09-03-2023, Drk84
+- (Partially) Fixed: Localized messages throwing errors in console when the speaker is not visibile. Partially because i can't still display the speaker name in the journal (Issue #1049)
+- Added: New locals (READ ONLY) in @GetHit trigger: local.damagePercentPhysical, local.damagePercentFire, local.damagePercentCold, local.damagePercentPoison, local.damagePercentEnergy
+         These locals contains the amount in % of the elemental damage inflicted, and thus they are available only with Elemental Engine enabled.
+		
+		

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -690,11 +690,12 @@ effect_bounce:
 	// MAGICF_IGNOREAR bypasses defense completely
 	if ( (uType & DAMAGE_MAGIC) && IsSetMagicFlags(MAGICF_IGNOREAR) )
 		uType |= DAMAGE_FIXED;
-
+	
+	bool fElemental = IsSetCombatFlags(COMBAT_ELEMENTAL_ENGINE);
 	// Apply armor calculation
 	if ( !(uType & (DAMAGE_GOD|DAMAGE_FIXED)) )
 	{
-		if ( IsSetCombatFlags(COMBAT_ELEMENTAL_ENGINE) )
+		if ( fElemental )
 		{
 			// AOS elemental combat
 			if ( iDmgPhysical == 0 )		// if physical damage is not set, let's assume it as the remaining value
@@ -730,6 +731,15 @@ effect_bounce:
 	Args.m_VarsLocal.SetNum("ItemDamageLayer", sm_ArmorDamageLayers[Calc_GetRandVal(CountOf(sm_ArmorDamageLayers))]);
 	Args.m_VarsLocal.SetNum("ItemDamageChance", 25);
 	Args.m_VarsLocal.SetNum("Spell", (int)spell);
+
+	if ( fElemental )
+	{
+		Args.m_VarsLocal.SetNum("DamagePercentPhysical", iDmgPhysical);
+		Args.m_VarsLocal.SetNum("DamagePercentFire", iDmgFire);
+		Args.m_VarsLocal.SetNum("DamagePercentCold", iDmgCold);
+		Args.m_VarsLocal.SetNum("DamagePercentPoison", iDmgPoison);
+		Args.m_VarsLocal.SetNum("DamagePercentEnergy", iDmgEnergy);
+	}
 
 	if ( IsTrigUsed(TRIGGER_GETHIT) )
 	{
@@ -845,7 +855,7 @@ effect_bounce:
 		if ( pSpellDef && pSpellDef->GetPrimarySkill(&iSpellSkill) )
 			iDisturbChance = pSpellDef->m_Interrupt.GetLinear(Skill_GetBase((SKILL_TYPE)iSpellSkill));
 
-		if ( iDisturbChance && IsSetCombatFlags(COMBAT_ELEMENTAL_ENGINE) && !pSpellDef->IsSpellType(SPELLFLAG_SCRIPTED) ) //If Protection spell has SPELLFLAG_SCRIPTED don't make this check.
+		if ( iDisturbChance && fElemental && !pSpellDef->IsSpellType(SPELLFLAG_SCRIPTED) ) //If Protection spell has SPELLFLAG_SCRIPTED don't make this check.
 		{
 			// Protection spell can cancel the disturb
 			CItem *pProtectionSpell = LayerFind(LAYER_SPELL_Protection);

--- a/src/game/clients/CClientMsg.cpp
+++ b/src/game/clients/CClientMsg.cpp
@@ -829,7 +829,7 @@ void CClient::addBarkParse( lpctstr pszText, const CObjBaseTemplate * pSrc, HUE_
 		{
             tchar * ppArgs[256];
 			int iQty = Str_ParseCmds(ptcBarkBuffer, ppArgs, CountOf(ppArgs), "," );
-			int iClilocId = Exp_GetVal( ppArgs[0] );
+			int iClilocId = Exp_GetVal( pszText ); //pszText holds the cliloc number, we can't use ppArgs[0] because if the string name exists it will contain the speaker name along with the cliloc number.
 			int iAffixType = Exp_GetVal( ppArgs[1] );
 			CSString CArgs;
 			for (int i = 3; i < iQty; ++i )
@@ -847,7 +847,7 @@ void CClient::addBarkParse( lpctstr pszText, const CObjBaseTemplate * pSrc, HUE_
 		{
             tchar * ppArgs[256];
 			int iQty = Str_ParseCmds(ptcBarkBuffer, ppArgs, CountOf(ppArgs), "," );
-			int iClilocId = Exp_GetVal( ppArgs[0] );
+			int iClilocId = Exp_GetVal(pszText ); //pszText holds the cliloc number, we can't use ppArgs[0] because if the string name exists it will contain the speaker name along with the cliloc number.
 			CSString CArgs;
 			for ( int i = 1; i < iQty; ++i )
 			{


### PR DESCRIPTION

- Added: New locals (READ ONLY) in @GetHit trigger: local.damagePercentPhysical, local.damagePercentFire, local.damagePercentCold, local.damagePercentPoison, local.damagePercentEnergy These locals contains the amount in % of the elemental damage inflicted, and thus they are available only with Elemental Engine enabled.