### PR TITLE
Possible fix for Npc double hit and @CombatEnd not firing and Fighting Memories not removed when fight is done.

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3249,3 +3249,7 @@ Fixed: Multi type items weren't calling the @Destroy triggers when removed. (Iss
 07-04-2023, Drk84
 - Fixed: ModMaxWeight not working on NPCs. (Issue #1061)
 - Fixed: SHIPMOVE command displaying an "invalid command" warning on the console if the ship can't move. (Issue #860)
+
+22-04-2023, Drk84
+- Fixed: NPC double hit. (Issue #1065)
+- Fixed: @CombatEnd not fired and Combat memories not removed when the fight is ended. (Issue #1055)

--- a/src/game/chars/CCharAttacker.cpp
+++ b/src/game/chars/CCharAttacker.cpp
@@ -248,7 +248,7 @@ void CChar::Attacker_Clear()
     ADDTOCALLSTACK("CChar::Attacker_Clear");
     if (IsTrigUsed(TRIGGER_COMBATEND))
     {
-        if (!Fight_IsActive() || !m_Fight_Targ_UID.IsValidUID() || !m_Fight_Targ_UID.CharFind())
+        if (m_lastAttackers.empty() || !Fight_IsActive() || !m_Fight_Targ_UID.IsValidUID() || !m_Fight_Targ_UID.CharFind())
         {
             OnTrigger(CTRIG_CombatEnd, this, 0);
         }

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -1243,6 +1243,10 @@ bool CChar::Fight_Clear(CChar *pChar, bool bForced)
     m_atFight.m_iSwingAnimation = 0;
     m_atFight.m_iSwingIgnoreLastHitTag = 0;
 
+	CItemMemory* pMemoryFight =  Memory_FindObj(m_Fight_Targ_UID);
+	if ( pMemoryFight && ( pMemoryFight->IsMemoryTypes(MEMORY_FIGHT) || pMemoryFight->IsMemoryTypes(MEMORY_IRRITATEDBY) ) )
+		pMemoryFight->Delete();
+
 	// Go to my next target.
 	if (m_Fight_Targ_UID == pChar->GetUID())
 		m_Fight_Targ_UID.InitUID();

--- a/src/game/chars/CCharNPCAct_Fight.cpp
+++ b/src/game/chars/CCharNPCAct_Fight.cpp
@@ -161,6 +161,9 @@ void CChar::NPC_Act_Fight()
     }
 
     // Review our targets periodically.
+    /* The code predates Sphere 56b and is used to find a new target. On the other hand, in combat, it is probably unnecessary anymore based on the details as follows;
+    * Switching the target and movement is handled by NPC_FightFindBestTarget() in the combat routines.
+    * It also break ups, some time, the NPC_ActFight trigger is all the condition were true.
     if (!IsStatFlag(STATF_PET) || (m_pNPC->m_Brain == NPCBRAIN_BERSERK))
     {
         int iObservant = (130 - Stat_GetAdjusted(STAT_INT)) / 20;
@@ -173,7 +176,7 @@ void CChar::NPC_Act_Fight()
             }
         }
     }
-
+    */
     CChar * pChar = m_Fight_Targ_UID.CharFind();
     if (pChar == nullptr || !pChar->IsTopLevel()) // target is not valid anymore ?
         return;


### PR DESCRIPTION
- Fixed: NPC double hit. (Issue #1065)
- Fixed: @CombatEnd not fired and Combat memories not removed when the fight is ended. (Issue #1055)