### PR TITLE
- Fixed: Timer not set when an ammunition item was placed on the ground and summon creature ID fix

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3282,3 +3282,7 @@ Fixed: Multi type items weren't calling the @Destroy triggers when removed. (Iss
 
 13-05-2023, Nolok
 - Fixed: Invalid MULTICOMPONENT and MULTILOCKDOWN tag on items throwing an exception.
+
+13-05-2023, Drk84
+- Fixed: Timer not set when an ammunition item was placed on the ground because the strike missed.  (Issue #1072) 
+- Fixed: Casting the SUMMON CREATURE spell while a fighting skill was active caused the spell creature ID to be resetted. (Issue #1070)

--- a/src/game/chars/CCharSkill.cpp
+++ b/src/game/chars/CCharSkill.cpp
@@ -2932,8 +2932,16 @@ int CChar::Skill_Fighting( SKTRIG_TYPE stage )
 
     if ((stage == SKTRIG_FAIL) || (stage == SKTRIG_ABORT))
     {
-        m_atFight.m_iRecoilDelay = 0;
-        m_atFight.m_iSwingAnimationDelay = 0;
+		/*Super cheap fix :
+		When we are casting the SUMMON CREATURE spell while we are in an active combat (we have an active fighting skill going on)
+		resetting both the RecoilDelay and the SwingAnimationDelay will also cause the ID of the summoned creatured to be resetted.
+		This only happens when the creature to be summoned is chosen on the default "summon menu".
+		*/
+		if ( !m_atMagery.m_iSummonID ) 
+		{
+			m_atFight.m_iRecoilDelay = 0;
+			m_atFight.m_iSwingAnimationDelay = 0;
+		}
         m_atFight.m_iSwingAnimation = 0;
         m_atFight.m_iSwingIgnoreLastHitTag = 0;
         return 0;

--- a/src/game/items/CItem.cpp
+++ b/src/game/items/CItem.cpp
@@ -1410,8 +1410,10 @@ bool CItem::MoveToUpdate(const CPointMap& pt, bool fForceFix)
 
 bool CItem::MoveToDecay(const CPointMap & pt, int64 iMsecsTimeout, bool fForceFix)
 {
+	if (!MoveToUpdate(pt, fForceFix))
+		return false;
 	SetDecayTime(iMsecsTimeout);
-	return MoveToUpdate(pt, fForceFix);
+	return true;
 }
 
 void CItem::SetDecayTime(int64 iMsecsTimeout, bool fOverrideAlways)


### PR DESCRIPTION
- Fixed: Timer not set when an ammunition item was placed on the ground because the strike missed.  (Issue #1072) 
- Fixed: Casting the SUMMON CREATURE spell while a fighting skill was active caused the spell creature ID to be resetted. (Issue #1070)