### PR TITLE
Poisonfix

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3299,3 +3299,8 @@ Fixed: Multi type items weren't calling the @Destroy triggers when removed. (Iss
 
 17-07-2023, Nolok
 - Added: Protection against infinite recursions in scripts and consequent crashes. Script parsing will not go further if the recursion gets too deep, showing a error message.
+
+17-08-2023, Tolokio (rastrero on discord)
+-Fixed: Now bottles are consumed and empty bottle is retrieved. Do eat_anim as well.
+       LACK: Poison bottles don't check or apply Potion's colddown. Dont know if it is desired. Will be added if requested.
+       

--- a/src/game/clients/CClientUse.cpp
+++ b/src/game/clients/CClientUse.cpp
@@ -280,10 +280,20 @@ bool CClient::Cmd_Use_Item( CItem *pItem, bool fTestTouch, bool fScript )
 			}
 			if ( RES_GET_INDEX(pItem->m_itPotion.m_Type) == SPELL_Poison )
 			{
-				// If we click directly on poison potion, we will drink poison and get ill.
-				// To use it on Poisoning skill, the skill will request to target the potion.
-				m_pChar->OnSpellEffect(SPELL_Poison, m_pChar, pItem->m_itSpell.m_spelllevel, nullptr);
-				return true;
+		                // If we click directly on poison potion, we will drink poison and get ill.
+		                // To use it on Poisoning skill, the skill will request to target the potion.
+		                // 
+		                //Let sphere find the empty bottle id (maybe someone script a poison on a pitcher)
+		                const CItemBase* pItemDef = pItem->Item_GetDef();
+		                ITEMID_TYPE idbottle = (ITEMID_TYPE)pItemDef->m_ttDrink.m_ridEmpty.GetResIndex();
+		                m_pChar->OnSpellEffect(SPELL_Poison, m_pChar, pItem->m_itSpell.m_spelllevel, nullptr);
+		                //
+		                m_pChar->UpdateAnimate(ANIM_EAT);
+		                pItem->ConsumeAmount();
+		                // Retrieve empty bottle, pitcher or whatever.
+		                if (idbottle != ITEMID_NOTHING)
+		                    m_pChar->ItemBounce(CItem::CreateScript(idbottle, m_pChar), false);
+		                return true;
 			}
 			if ( RES_GET_INDEX(pItem->m_itPotion.m_Type) == SPELL_Explosion )
 			{


### PR DESCRIPTION
Fix for poison bottles when used by Dclick.
-Potion is consumed now
-Empty bottle is retrieved now.
-Eat anim added.
 
 IT lacks Cooldown for poison bottles. Need to study some things to implement it. 