### PR TITLE
Poisonfix

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3305,6 +3305,9 @@ Fixed: Multi type items weren't calling the @Destroy triggers when removed. (Iss
 	-Now it dosnt raise magic resistance if poison comes from a potion.
 	-Potion is consumed when dclick and the Empty bottle retrieved into backpack.
 	-Eating animation added.
+	-Poison str and ticks fixed.
 -Known Issues:
-	-Poison effect is the same always no matter poison strenght. And duration is short. 
-	-There is no cooldown for poison bottles (complex to implement and not really needed I think)
+	-There is no cooldown for poison bottles.
+         (Should a player who drink a poison wait for cooldown until he can drink a cure potion?
+          or should a player be able to drink 1000 potion in one minute? Can`t have both unless we
+	  add a specific cooldown just for poison potions.) 

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3299,3 +3299,12 @@ Fixed: Multi type items weren't calling the @Destroy triggers when removed. (Iss
 
 17-07-2023, Nolok
 - Added: Protection against infinite recursions in scripts and consequent crashes. Script parsing will not go further if the recursion gets too deep, showing a error message.
+
+17-08-2023, Tolokio the Rastrero
+-FIXED: (Poison`s potions)
+	-Now it dosnt raise magic resistance if poison comes from a potion.
+	-Potion is consumed when dclick and the Empty bottle retrieved into backpack.
+	-Eating animation added.
+-Known Issues:
+	-Poison effect is the same always no matter poison strenght. And duration is short. 
+	-There is no cooldown for poison bottles (complex to implement and not really needed I think)

--- a/src/game/clients/CClientUse.cpp
+++ b/src/game/clients/CClientUse.cpp
@@ -286,7 +286,7 @@ bool CClient::Cmd_Use_Item( CItem *pItem, bool fTestTouch, bool fScript )
 					//Let sphere find the empty "bottle"(maybe someone script a poison on a pitcher)
 					const CItemBase* pItemDef = pItem->Item_GetDef();
 					ITEMID_TYPE idbottle = (ITEMID_TYPE)pItemDef->m_ttDrink.m_ridEmpty.GetResIndex();
-					m_pChar->OnSpellEffect(SPELL_Poison, m_pChar, pItem->m_itSpell.m_spelllevel, pItem );
+					m_pChar->OnSpellEffect(SPELL_Poison, m_pChar, pItem->m_itPotion.m_dwSkillQuality, pItem );
 					//Sound(sm_DrinkSounds[Calc_GetRandVal(CountOf(sm_DrinkSounds))]);
 					m_pChar->UpdateAnimate(ANIM_EAT);
 					pItem->ConsumeAmount();

--- a/src/game/clients/CClientUse.cpp
+++ b/src/game/clients/CClientUse.cpp
@@ -280,11 +280,21 @@ bool CClient::Cmd_Use_Item( CItem *pItem, bool fTestTouch, bool fScript )
 			}
 			if ( RES_GET_INDEX(pItem->m_itPotion.m_Type) == SPELL_Poison )
 			{
-				// If we click directly on poison potion, we will drink poison and get ill.
-				// To use it on Poisoning skill, the skill will request to target the potion.
-				m_pChar->OnSpellEffect(SPELL_Poison, m_pChar, pItem->m_itSpell.m_spelllevel, nullptr);
-				return true;
-			}
+					// If we click directly on poison potion, we will drink poison and get ill.
+					// To use it on Poisoning skill, the skill will request to target the potion.
+					// 
+					//Let sphere find the empty "bottle"(maybe someone script a poison on a pitcher)
+					const CItemBase* pItemDef = pItem->Item_GetDef();
+					ITEMID_TYPE idbottle = (ITEMID_TYPE)pItemDef->m_ttDrink.m_ridEmpty.GetResIndex();
+					m_pChar->OnSpellEffect(SPELL_Poison, m_pChar, pItem->m_itSpell.m_spelllevel, pItem );
+					//Sound(sm_DrinkSounds[Calc_GetRandVal(CountOf(sm_DrinkSounds))]);
+					m_pChar->UpdateAnimate(ANIM_EAT);
+					pItem->ConsumeAmount();
+					// Create the empty bottle ?
+					if (idbottle != ITEMID_NOTHING)
+						m_pChar->ItemBounce(CItem::CreateScript(idbottle, m_pChar), false);
+					return true;
+				}
 			if ( RES_GET_INDEX(pItem->m_itPotion.m_Type) == SPELL_Explosion )
 			{
 				// Throw explosion potion


### PR DESCRIPTION
Fix for poison bottles when u dclick on one.  
```
-FIXED: (Poison`s potions)
	-Now it dosnt raise magic resistance if poison comes from a potion.
	-Potion is consumed when dclick and the Empty bottle retrieved into backpack.
	-Eating animation added.
	-Poison str and duration fixed.
-Known Issues:
	-There is no cooldown for poison bottles.
         (Should a player who drink a poison wait for cooldown until he can drink a cure potion?
          or should a player be able to drink 1000 potion in one minute? Can`t have both unless we
	  add a specific cooldown just for poison potions. What does OSI?) 
```
	
This fix is done due this report of jhobean	

![image](https://github.com/Sphereserver/Source-X/assets/20745578/6cf98f77-9ffd-447f-97d0-44abe14eeadb)

On a clean build, u need to activate this option on sphere.ini or poison will not take effect.

![image](https://github.com/Sphereserver/Source-X/assets/20745578/5ae58b74-2dca-4ecd-a48a-78c4d6f5b35b)

In OSI jhobean tested u get poisoned if u dclick on poison bottle.

