### PR TITLE
Poison drk

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3299,3 +3299,7 @@ Fixed: Multi type items weren't calling the @Destroy triggers when removed. (Iss
 
 17-07-2023, Nolok
 - Added: Protection against infinite recursions in scripts and consequent crashes. Script parsing will not go further if the recursion gets too deep, showing a error message.
+
+21-08-2023, Rastrero/Drk84
+-Fixed-> Removed exception for poison bottles at CClientUSe.cpp so now poison potions are handled as any other potion at CCharuse.cpp
+         Thx Drk84 for the suggestion. I dont understand why there was that exception done. Are we missing something?

--- a/src/game/clients/CClientUse.cpp
+++ b/src/game/clients/CClientUse.cpp
@@ -278,13 +278,6 @@ bool CClient::Cmd_Use_Item( CItem *pItem, bool fTestTouch, bool fScript )
 				SysMessageDefault(DEFMSG_ITEMUSE_POTION_FAIL);
 				return false;
 			}
-			if ( RES_GET_INDEX(pItem->m_itPotion.m_Type) == SPELL_Poison )
-			{
-				// If we click directly on poison potion, we will drink poison and get ill.
-				// To use it on Poisoning skill, the skill will request to target the potion.
-				m_pChar->OnSpellEffect(SPELL_Poison, m_pChar, pItem->m_itSpell.m_spelllevel, nullptr);
-				return true;
-			}
 			if ( RES_GET_INDEX(pItem->m_itPotion.m_Type) == SPELL_Explosion )
 			{
 				// Throw explosion potion


### PR DESCRIPTION
-Fixed-> Poison bottle now works as any other potion when u drink it. Seems to be working right but not deeply tested.


Notes:
Someone did an exception for poison`s potions at CClientUse.cpp so It didnt pass through CCharUse.cpp->use_drink(pItem)
Probably someone forget to remove the exception once it was fixed? Are we missing something? I think if there is any problem it should be at the part of the potion marker but I dont find any.

Thx Drk84 for the fix.