### PR TITLE
Fix PacketDeath to pass the corpse type to the client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,3 @@ CMakeCache.txt
 /lib/mariadb/config.h
 /lib/mariadb/ma_config.h
 /lib/mariadb/mariadb_version.h
-/out/build

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ CMakeCache.txt
 /lib/mariadb/config.h
 /lib/mariadb/ma_config.h
 /lib/mariadb/mariadb_version.h
+/out/build

--- a/src/network/send.cpp
+++ b/src/network/send.cpp
@@ -3540,12 +3540,12 @@ PacketMessageUNICODE::PacketMessageUNICODE(const CClient* target, const nachar *
  ***************************************************************************/
 PacketDeath::PacketDeath(CChar* dead, CItemCorpse* corpse, bool fFrontFall) : PacketSend(XCMD_CharDeath, 13, PRI_NORMAL)
 {
-	UnreferencedParameter(fFrontFall);
+	//UnreferencedParameter(fFrontFall);
 	ADDTOCALLSTACK("PacketDeath::PacketDeath");
 
 	writeInt32(dead->GetUID());
 	writeInt32(corpse == nullptr ? 0 : (dword)corpse->GetUID());
-	writeInt32(0);
+	writeInt32(fFrontFall);
 }
 
 


### PR DESCRIPTION
fFrontFall is the type of the corpse create by Sphere, it wasn't written on PacketDeath so the client didn't know what death animation to use. On ClassicUO sometimes the death animation didn't match the corpse type, with this change it's fixed.