### PR TITLE
Add Argument to @mount trigger for changing anim

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3426,3 +3426,9 @@ Additionally, the problem of zig-zag issue following in the South direction has 
 - Fixed: Removing from client's view an object while it's being deleted, in some corner cases made the server crash (Issue #1119).
 - Fixed: Guildstone removal caused an exception (Issue #1165).
 - Fixed: In-game chat not working correctly and generating exceptions since last update (Issue #1140).
+
+02-11-2023, Jhobean
+- Modified: @Mount added argument ARGN1
+            ARGN1 (rw) = The itemID of the item containing the animation use when moounting. (Anim # is in tiledata of this item)
+            NOTE: When mounting a pet you'll read a non sense random value but you can replace it by an ITEMID to force anim
+            EX: 03ea6 for Llama anim or 03e9f for gray horse anim. Yes 03ea6 is a ship part but in tiledata it link to anim 828

--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -2407,7 +2407,7 @@ CItem * CChar::Make_Figurine( const CUID &uidOwner, ITEMID_TYPE id )
 	pItem->SetType(IT_FIGURINE);
 	pItem->SetName(GetName());
 	pItem->SetHue(GetHue());
-	pItem->m_itFigurine.m_ID = GetID();	// Base type of creature.
+	pItem->m_itFigurine.m_ID = GetID();	// Base type of creature. (More1 of i_memory)
 	pItem->m_itFigurine.m_UID = GetUID();
 	pItem->m_uidLink = uidOwner;
 
@@ -2749,11 +2749,14 @@ bool CChar::Horse_Mount(CChar *pHorse)
 	if ( IsTrigUsed(TRIGGER_MOUNT) )
 	{
 		CScriptTriggerArgs Args(pHorse);
-   		if ( OnTrigger(CTRIG_Mount, this, &Args) == TRIGRET_RET_TRUE )
-			return false;
+        Args.m_iN1 = memoryId;
+   		if ( OnTrigger(CTRIG_Mount, this, &Args) == TRIGRET_RET_TRUE )   
+		    return false;
+        else
+            memoryId = ITEMID_TYPE(Args.m_iN1);//(ITEMID_TYPE) Args.m_iN1;
 	}
 
-	// Create the figurine for the horse
+	// Create the figurine for the horse (Memory item equiped on layer 25 of the player)
 	CItem * pMountItem = pHorse->Make_Figurine(GetUID(), memoryId);
 	if ( !pMountItem)
 		return false;


### PR DESCRIPTION
With this, we are able to force a different anim when mounting a mount. Ex: you can force a Lama Anim when mounting an Horse.....

Yes it look useless but I needed it for a custom script and I wanted to share it because it could help someone else. I'll update wiki after merge.

Tested on Orion and OSI client

See example here:
https://cdn.discordapp.com/attachments/1019766173287587881/1169434661198503956/OrionUO64_WxtKEL29ww.gif?ex=655563e6&is=6542eee6&hm=e157db987c3cb87617e0a303bce78ad16081fe6e4874716bf4ff300787dac94c&