### PR TITLE
CSFile Windows creation file mode fix

### DIFF
--- a/src/common/sphere_library/CSFile.cpp
+++ b/src/common/sphere_library/CSFile.cpp
@@ -137,7 +137,11 @@ bool CSFile::_Open( lpctstr ptcFilename, uint uiModeFlags )
 
     _fileDescriptor = CreateFile( ptcFilename, dwDesiredAccess, dwShareMode, nullptr, dwCreationDisposition, FILE_ATTRIBUTE_NORMAL, nullptr );
 #else
-    _fileDescriptor = open( ptcFilename, uiModeFlags );
+    uint uiFilePermissions = 0;
+    if (uiModeFlags & OF_CREATE)
+        uiFilePermissions = (S_IRWXU | S_IRWXG | S_IRWXO); //777
+    
+    _fileDescriptor = open( ptcFilename, uiModeFlags, uiFilePermissions);
 #endif // _WIN32
 
     return (_fileDescriptor != _kInvalidFD);

--- a/src/common/sphere_library/CSFile.cpp
+++ b/src/common/sphere_library/CSFile.cpp
@@ -131,7 +131,7 @@ bool CSFile::_Open( lpctstr ptcFilename, uint uiModeFlags )
         dwShareMode = 0;
 
     if ( uiModeFlags & OF_CREATE )
-        dwCreationDisposition = (OPEN_ALWAYS|CREATE_NEW);
+        dwCreationDisposition = CREATE_ALWAYS;
     else
         dwCreationDisposition = OPEN_EXISTING;
 

--- a/src/game/chars/CChar.cpp
+++ b/src/game/chars/CChar.cpp
@@ -1558,7 +1558,6 @@ bool CChar::SetDispID(CREID_TYPE id)
     return true;
 }
 
-// Just set the base id and not the actual display id.
 // NOTE: Never return nullptr
 void CChar::SetID( CREID_TYPE id )
 {
@@ -1576,7 +1575,10 @@ void CChar::SetID( CREID_TYPE id )
 
 		pCharDef = CCharBase::FindCharBase(id);
 	}
-
+    
+    //Update DispId
+    m_dwDispIndex = id;
+    
 	ASSERT(pCharDef != nullptr);
 
 	CCharBase* pCharOldDef = Char_GetDef();


### PR DESCRIPTION
The correct mode to create a file in Windows, if not exists, and open it, if exists, is CREATE_ALWAYS. With (OPEN_ALWAYS | CREATE_NEW) the mode is set to 5 (TRUNCATE_EXISTING) and if the file doesn't exists the CreateFile function return an error. https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-createfilea