### PR TITLE
FIx for Negative STAT by negative MODSTAT

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3779,3 +3779,6 @@ Added: 'H' shortcut for variables to get the value as hexadecimal.
 	// ITEM_CANTIMER_IN_CONTAINER	1	// Items can hold a timer even if equipped.
 - Added: item CAN flag (Issue #1180):
 	CAN_I_TIMER_CONTAINED   0x40000000  // This item (if not "sleeping") can have a timer even if inside a container (overrides global default behavior).
+
+06/07/2024, Tolokio
+FIXED-> "ushort CChar::Stat_GetAdjusted( STAT_TYPE i ) const" will set any negative value to 0 before ushort is done and retrieved. I dont agree with this fix.

--- a/src/game/chars/CCharStat.cpp
+++ b/src/game/chars/CCharStat.cpp
@@ -295,7 +295,10 @@ uint CChar::Stat_GetSum() const
 ushort CChar::Stat_GetAdjusted( STAT_TYPE i ) const
 {
 	ADDTOCALLSTACK("CChar::Stat_GetAdjusted");
-    return ushort(Stat_GetBase(i) + Stat_GetMod(i));
+    int t = Stat_GetBase(i) + Stat_GetMod(i);
+    if (t < 0)
+        t = 0;
+    return ushort(t)
 }
 
 ushort CChar::Stat_GetBase( STAT_TYPE i ) const


### PR DESCRIPTION
This is the most lazy fix we could do for modstat's issue. (but maybe better than nothing or even other fixes.)


![image](https://github.com/Sphereserver/Source-X/assets/20745578/54b6651b-8d44-4891-af9c-ba5b7a9813f8)

**Is there an alternative by Script?**

Yes, Drk84 posted this method for STR and MODSTR. 
![image](https://github.com/Sphereserver/Source-X/assets/20745578/3ca52277-3949-44d5-a235-1382cb63d346)

 You would need one script like this for each modstat and modmaxstat (x6). So the fix is really bigger than this, but that is the method. You would also need to adapt your equip's events to work with the new f_modstat instead the modstat.


