### PR TITLE
Added spherecustom.ini definition

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3808,3 +3808,136 @@ Added: 'H' shortcut for variables to get the value as hexadecimal.
 	New values:
 	SPELLFLAG_FIELD_RANDOMDECAY     02000
 	SPELLFLAG_NO_ELEMENTALENGINE    04000
+
+10-08-2024, DavideRei
+- Added: read mobtypes.txt (if available among mul files) and cache it to check animations type when using creatures animations
+- Added: alert anim on NPCs when they start combat, pillage anim when they loot something (items on ground or in bodies) and "summon" anim when they are summoned or added
+- Modified: now standard anims (SEA_MONSTER, ANIMAL, MONSTER) and UOP anims are handled correctly depending on which actions anim they have on anim files (checked on last client version).
+	Please note that some actions are handled by the client (for example walk, run, fly, getHit while flying, die) and they could not work depending on which client you are using.
+- Added: missing/new actions to be used with .ANIM command.
+    ANIM_ALERT              = 35,
+    ANIM_THROW              = 36,
+    ANIM_PILLAGE            = 37,
+    ANIM_STOMP              = 38,
+    ANIM_FLY                = 39,
+    ANIM_LAND               = 40,
+    ANIM_GETHIT_AIR         = 41,
+    ANIM_SUMMON             = 42,
+    ANIM_SPECIAL            = 43,   //UOP anims
+    ANIM_BOSS_SPECIAL_1     = 44,   //Only few UOP anims: Order Variant, Chaos Variant, Stygian Dragon, Scalis
+    ANIM_BOSS_SPECIAL_2     = 45,   //Only few UOP anims: Order Variant, Chaos Variant, Stygian Dragon, Scalis
+
+- Modified: now custom anims can be handled by scripts using ANIM command under CHARDEF, to set which anim actions they have/don't have, using the following flags.
+	MONSTER (H slot) default configuration is with actions: 0 (Walk), 1 (Stand), 2 (Die1), 3 (Die2), 4 (Attack1), 5 (Attack2), 6 (Attack3), 10 (GetHit), 11 (Pillage), 15 (Block Right), 16 (Block Left), 17 (Idle), 18 (Fidget)
+    No DIE2 action		= 01,
+    No ATTACK1 action   = 02,
+    No ATTACK2 action   = 04,
+    No ATTACK3 action   = 08,
+    No GETHIT action    = 010,
+    No PILLAGE action   = 020,
+    STOMP action		= 040,
+    CAST2 action        = 080,
+    CAST3 action        = 0100,
+    No BLOCKR action    = 0200,
+    No BLOCKL action    = 0400,
+    No FIDGET1 action   = 0800,
+    No FIDGET2 action   = 01000,
+    FLY action          = 02000,
+    Anims with Attacks 1-2-3 in actions 9,10,11 and with GetHit in action 20 (there are many custom WOW anims with this configuration) = 0x10000
+
+	ANIMAL (L slot) default configuration is with all actions: 1 - 12
+    No EAT action       = 01,
+    No ALERT action     = 02,
+    No ATTACK2 action   = 04,
+    No GETHIT action    = 08,
+    No FIDGET1 action   = 010,
+    No FIDGET2 action   = 020,
+    No LIEDOWN action   = 040,
+    No DIE2 action      = 080
+
+	So for example if you have a MONSTER (H slot) flying custom anim, with Cast2 action but not Pillage action you can set ANIM=020A0
+	If you have a custom anim with default configuration, you don't need to set ANIM=
+
+10-08-2024, Gladie
+- Fixed: CAN_I_DAMAGEABLE not updating status bar (PR #1259, issues #1248, #1260).
+
+09-09-2024, Nolok
+  WARNING! POTENTIALLY BREAKING CHANGE! Scripts will need to be updated.
+- Changed: since there was too much data to be stored in the FACTION/SLAYER property, so that it sometimes couldn't fit and caused issues,
+	it has been split in two different properties:
+	  - FACTION/SLAYER_GROUP (expects a bitmask, max value of the usable flag: 0x800000),
+	  - FACTION/SLAYER_SPECIES (plain number, max value 255).
+	    SPECIES with index/value 1 are always considered to be SuperSlayers for their group.
+	Those properties are stored in the ComponentProps ItemEquippable and Char.
+- Changed: SLAYER now works only on items, FACTION on characters. Before, they were synonyms and could be used on both chars and items to access the same property.
+- Removed: unused properties SLAYER, SLAYER_LESSER, SLAYER_SUPER, SLAYER_MISC.
+- Added: log message when a new thread is created or a thread is being renamed.
+
+10-09-2024, Nolok
+- Updated: f_onserver_connectreq_ex now is called whenever an ini connection limit is exceeded (pings, max connections...).
+    Now it stores these parameters:
+    - ARGS  = IP address
+    - LOCAL.TIME_CUR_CONNECTED_MS (RO)  = Monotonic system time when this connection request was handled (milliseconds)
+    - LOCAL.TIME_LAST_CONNECTED_MS (RO) = Monotonic system time of the previous connection attempt/request (milliseconds)
+    - LOCAL.PINGS (RO)                  = Current number of "pings" (connection attempts, the number decays over time)
+    - LOCAL.CONNECTION_REQUESTS (RO)    = Current number of connection requests since i remember of this IP
+    - LOCAL.ALIVE_CONNECTIONS (RO)      = How many active and successiful connections i have with this IP
+    - LOCAL.PENDING_CONNECTING (RO)     = How many active connection attempts or incomplete connections i have to this IP
+    - LOCAL.BAN_TIMEOUT (RW)            = unchanged -> 5 * 60 (default), seconds to keep banned the ip from new connections to the server (permanent if negative).
+
+    RETURN -1: Don't do anything, let the connection pass.
+    RETURN 1:  Only reject the connection.
+    RETURN 2:  Reject and ban the IP for <LOCAL.BAN_TIMEOUT> seconds.
+
+17-09-2024, Nolok
+- Fixed: When acquiring a new pet follower, CurFollower incremented by 1 regardless of pet's FollowerSlots value (Issue #1251).
+- Fixed: dynamic FOLLOWERSLOTS property wasn't correctly saved and loaded from a worldsave.
+- Added: dynamic FOLLOWERSLOTS property is now copied to the figurine as TAG.FOLLOWERSLOTS when an NPC is shrinked, and it's applied back when unshrinked.
+- Fixed: "mounting"/guiding through the ship pilot exit/dismount bug.
+
+21-09-2024, Nolok
+- Changed: CURFOLLOWER.n now works as a reference for that pet, meaning it can be accessed as an object (like with FINDID).
+- Changed: added desired FollowerSlots as a second argument to CURFOLLOWER.ADD. Default value: its FollowerSlots.
+- Changed: @FollowerUpdate ARGN1 and ARGN2 are now read-only. Having them RW and actually get them working would have meant many other changes, breaking script compatibility.
+- Fixed: CURFOLLOWER.DEL/DELETE/CLEAR not working properly.
+
+03-10-2024, Nolok
+- Fixed: LIST.ADD ignoring quoted arguments (Issue #1247).
+- Fixed: FOOD and MAXFOOD not being stored in the worldsave file (Issue #1289).
+- Added: CURFOLLOWER.CHARCOUNT, to return the raw number of characters you own/that are following you. Plain CURFOLLOWER returns the current total FOLLOWERSLOTS you own.
+- Changed: removed CURFOLLOWER.DEL and CURFOLLOWER.DELETE in favor of the more specific:
+    CURFOLLOWER.DELUID: The same as .DEL/DELETE, just removed the pet via its UID.
+    CURFOLLOWER.DELINDEX: Removes the pet via its id in the (cur)follower list for that owner.
+- Added: spells with SPELLFLAG_SUMMON now accept LOCAL.FollowerSlotsOverride in the triggers @Success and @SpellSuccess. Default value (do not override): -1.
+
+13-10-2024, Jhobean
+- Added: @PetRelease trigger work like @petdesert and return 1 to prevent the pet from being released.
+
+16-10-2024, xwerswoodx
+- Added: spherecustom.ini definition has been added to Sphere.
+    This allows you to override Sphere settings without touching the Sphere.ini file.
+    For example, when you want to switch from an older Sphere version to 56x or when you haven't updated for a long time, instead of checking all the new data
+  added to Sphere.ini one by one, you can simply use your old sphere.ini as spherecustom.ini. This way, newly added data will take the default settings from 
+  Sphere.ini, while your previous custom settings will override the defaults without requiring any further adjustments.
+    On the other hand, it helps you maintain a clean Sphere.ini. Instead of directly changing the Sphere.ini settings, you can create a spherecustom.ini file 
+  and add only the settings you want to change there, allowing you to easily track the changes without modifying Sphere.ini.
+    Here's an example of a spherecustom.ini:
+      [SPHERE]
+      AGREE=1
+
+      // Server Data
+      ServName=MyCuteServer
+      ServIP=255.255.255.255
+      ServPort=2593
+
+      // Server Settings
+      AdvancedLos=2
+      GuardsInstatntKill=0
+      FeatureT2A = 01|02
+
+      [SERVERS]
+      MyCuteServer
+      255.255.255.255
+      2593
+
+      [EOF]

--- a/src/game/CServerConfig.h
+++ b/src/game/CServerConfig.h
@@ -606,6 +606,7 @@ public:
 	// End INI file options.
 
 	CResourceScript m_scpIni;       // Keep this around so we can link to it.
+    CResourceScript m_scpCustomIni; // Custom optional spherecustom.ini
 	CResourceScript m_scpCryptIni;  // Encryption keys are in here
 
 public:

--- a/src/network/receive.cpp
+++ b/src/network/receive.cpp
@@ -2495,6 +2495,17 @@ bool PacketClientVersion::onReceive(CNetState* net)
 	return true;
 }
 
+/***************************************************************************
+*
+*
+*	Packet 0xBE : PacketAssistVersion				assist version
+*
+*
+***************************************************************************/
+PacketAssistVersion::PacketAssistVersion() : Packet(0)
+{
+}
+PacketAssistVersion::~PacketAssistVersion() = default;
 
 /***************************************************************************
  *


### PR DESCRIPTION
- Added: spherecustom.ini definition has been added to Sphere.

1. This allows you to override Sphere settings without touching the Sphere.ini file.

2. For example, when you want to switch from an older Sphere version to 56x or when you haven't updated for a long time, instead of checking all the new data added to Sphere.ini one by one, you can simply use your old sphere.ini as spherecustom.ini. This way, newly added data will take the default settings from Sphere.ini, while your previous custom settings will override the defaults without requiring any further adjustments.

3. On the other hand, it helps you maintain a clean Sphere.ini. Instead of directly changing the Sphere.ini settings, you can create a spherecustom.ini file and add only the settings you want to change there, allowing you to easily track the changes without modifying Sphere.ini.

4. Here's an example of a spherecustom.ini:
```
[SPHERE]
AGREE=1

// Server Data
ServName=MyCuteServer
ServIP=255.255.255.255
ServPort=2593

// Server Settings
AdvancedLos=2
GuardsInstatntKill=0
FeatureT2A = 01|02

[SERVERS]
MyCuteServer
255.255.255.255
2593

[EOF]
```