### PR TITLE
Added NOREJOIN tag for corpses

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3914,3 +3914,7 @@ Added: 'H' shortcut for variables to get the value as hexadecimal.
 
 13-10-2024, Jhobean
 - Added: @PetRelease trigger work like @petdesert and return 1 to prevent the pet from being released.
+
+25-10-2024, canerksk
+- Added: Added NOREJOIN tag for corpses, If the NOREJOIN tag is one, the player cannot come back to life on that corpse. That is, the player comes back to life but not on the corpse.
+	This tag does not prevent the player from coming back to life, it just prevents them from respawning on that corpse. The player always comes back to life, but not on that corpse.

--- a/src/game/items/CItemCorpse.cpp
+++ b/src/game/items/CItemCorpse.cpp
@@ -150,6 +150,8 @@ CItemCorpse *CChar::FindMyCorpse( bool ignoreLOS, int iRadius ) const
 			break;
 		if ( !pItem->IsType(IT_CORPSE) )
 			continue;
+        if (pItem->m_TagDefs.GetKeyNum("NOREJOIN")) // OWNERS OF THE BODIES WITH THIS TAG SHOULD NOT STAND ON THE BODIES
+            continue;
 		CItemCorpse *pCorpse = dynamic_cast<CItemCorpse*>(pItem);
 		if ( !pCorpse || (pCorpse->m_uidLink != GetUID()) )
 			continue;

--- a/src/game/items/CItemCorpse.cpp
+++ b/src/game/items/CItemCorpse.cpp
@@ -150,7 +150,7 @@ CItemCorpse *CChar::FindMyCorpse( bool ignoreLOS, int iRadius ) const
 			break;
 		if ( !pItem->IsType(IT_CORPSE) )
 			continue;
-        if (pItem->m_TagDefs.GetKeyNum("NOREJOIN")) // OWNERS OF THE BODIES WITH THIS TAG SHOULD NOT STAND ON THE BODIES
+        if (pItem->m_TagDefs.GetKeyNum("NOREJOIN")) // The owner should not rejoin this body even if resurrected on top of it.
             continue;
 		CItemCorpse *pCorpse = dynamic_cast<CItemCorpse*>(pItem);
 		if ( !pCorpse || (pCorpse->m_uidLink != GetUID()) )


### PR DESCRIPTION
If the NOREJOIN tag is one, the player cannot come back to life on that corpse. That is, the player comes back to life but not on the corpse.
	This tag does not prevent the player from coming back to life, it just prevents them from respawning on that corpse. The player always comes back to life, but not on that corpse.

Issue #1292
