### PR TITLE
New optionflag OF_PetBehaviorOwnerNeutral

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3914,3 +3914,7 @@ Added: 'H' shortcut for variables to get the value as hexadecimal.
 
 13-10-2024, Jhobean
 - Added: @PetRelease trigger work like @petdesert and return 1 to prevent the pet from being released.
+
+25-10-2024, canerksk
+- Added: New optionflag OF_PetBehaviorOwnerNeutral
+	If this setting is enabled, pets you own will appear to you with the original noto (old behavior). If this setting is not enabled, the assets you own will always appear natural to you. This setting only applies when the owning character is looking at the asset they own. It does not apply when someone else is looking at the asset you own.

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3918,3 +3918,9 @@ Added: 'H' shortcut for variables to get the value as hexadecimal.
 25-10-2024, canerksk
 - Added: New optionflag OF_PetBehaviorOwnerNeutral
 	If this setting is enabled, pets you own will appear to you with the original noto (old behavior). If this setting is not enabled, the assets you own will always appear natural to you. This setting only applies when the owning character is looking at the asset they own. It does not apply when someone else is looking at the asset you own.
+
+26-10-2024, canerksk
+- Added: New OVERRIDE.MOVESTYLE tag and OF_NPCMovementOldStyle
+	Old style NPC walking has been added as an option.
+	If OVERRIDE.MOVESTYLE=1 is given to an entity, this indicates that the movement of that entity will be done using the old style calculation.
+	You can use OF_NPCMovementOldStyle to apply to all entities without needing a tag.

--- a/src/game/CServerConfig.h
+++ b/src/game/CServerConfig.h
@@ -88,7 +88,8 @@ enum OF_TYPE
     OF_AllowContainerInsideContainer = 0x0800000,    //Allow containers inside other containers even if they are heavier than the container being inserted into.
     OF_VendorStockLimit              = 0x01000000,   // Limits how much of an item a vendor can buy using the value set in the TEMPLATE. Format: BUY=ID,AMOUNT
     OF_EnableGuildAlignNotoriety     = 0x02000000,    // If enabled, guilds with the same alignment will see each other as enemy or ally.
-    OF_PetBehaviorOwnerNeutral       = 0x04000000 // Should my pets always appear natural to me?
+    OF_PetBehaviorOwnerNeutral       = 0x04000000, // Should my pets always appear natural to me?
+    OF_NPCMovementOldStyle           = 0x06000000 // Required setting to make NPCs run like in the old version.
 };
 
 /**

--- a/src/game/CServerConfig.h
+++ b/src/game/CServerConfig.h
@@ -87,7 +87,8 @@ enum OF_TYPE
     OF_OWNoDropCarriedItem          = 0x0400000,     // When overweighted, don't drop items on ground when moving them (or using BOUNCE) and checking if you can carry them.
     OF_AllowContainerInsideContainer = 0x0800000,    //Allow containers inside other containers even if they are heavier than the container being inserted into.
     OF_VendorStockLimit              = 0x01000000,   // Limits how much of an item a vendor can buy using the value set in the TEMPLATE. Format: BUY=ID,AMOUNT
-    OF_EnableGuildAlignNotoriety     = 0x02000000    // If enabled, guilds with the same alignment will see each other as enemy or ally.
+    OF_EnableGuildAlignNotoriety     = 0x02000000,    // If enabled, guilds with the same alignment will see each other as enemy or ally.
+    OF_PetBehaviorOwnerNeutral       = 0x04000000 // Should my pets always appear natural to me?
 };
 
 /**

--- a/src/game/chars/CCharNPCAct.cpp
+++ b/src/game/chars/CCharNPCAct.cpp
@@ -585,61 +585,101 @@ int CChar::NPC_WalkToPoint( bool fRun )
 	UpdateMove(ptOld);
 
 	EXC_SET_BLOCK("Speed counting");
-	// How fast can they move.
-	int64 iTickNext;
 
-	// TAG.OVERRIDE.MOVERATE
-	int64 tTick;
-    CVarDefCont * pVal = GetKey("OVERRIDE.MOVEDELAY", true);
-    if (pVal)
+    // How fast can they move.
+    int64 iTickNext;
+    CVarDefCont *pValMoveStyle = GetKey("OVERRIDE.MOVESTYLE", true);
+
+    if (pValMoveStyle || IsSetOF(OF_NPCMovementOldStyle))
     {
-        iTickNext = pVal->GetValNum();  // foot walking speed
-        if (IsStatFlag(STATF_ONHORSE | STATF_HOVERING)) // On Mount
-        {
-            if (IsStatFlag(STATF_FLY))  // Running
-            {
-                iTickNext /= 4; // 4 times faster when running while it's on a mount
-            }
-            else
-            {
-                iTickNext /= 2; // 2 times faster when walking while it's on a mount
-            }
-        }
-        else
-        {
-            if (IsStatFlag(STATF_FLY))
-            {
-                iTickNext /= 2; // 2 times faster when running.
-            }
-        }
-    }
-    else
-    {
-        CVarDefCont * pValue = GetKey("OVERRIDE.MOVERATE", true);
-        if (pValue)
-            tTick = pValue->GetValNum();	//Taking value from tag.override.moverate
-        else
-            tTick = pCharDef->m_iMoveRate;	//no tag.override.moverate, we get default moverate (created from ini's one).
-        // END TAG.OVERRIDE.MOVERATE
         if (fRun)
         {
-            if (IsStatFlag(STATF_PET))	// pets run a little faster.
+            if (IsStatFlag(STATF_PET)) // pets run a little faster.
             {
                 if (iDex < 75)
                     iDex = 75;
             }
-            iTickNext = MSECS_PER_SEC / 4 + g_Rand.GetValFast(int32(100 - (iDex*tTick) / 100) / 5) * MSECS_PER_SEC / 10;   // TODO MSEC to TICK? custom timers for npc's movement?
+            iTickNext = MSECS_PER_SEC / 4 + g_Rand.GetValFast((100 - iDex) / 5) * MSECS_PER_SEC / 10;
         }
         else
-            iTickNext = MSECS_PER_SEC + g_Rand.GetValFast(int32(100 - (iDex*tTick) / 100) / 3) * MSECS_PER_SEC / 10;
+            iTickNext = MSECS_PER_SEC + g_Rand.GetValFast((100 - iDex) / 3) * MSECS_PER_SEC / 10;
+
+	    CVarDefCont *pValue = GetKey("OVERRIDE.MOVERATE", true);
+        if (pValue)
+        {
+            int64 tTick = pValue->GetValNum();
+            if (tTick < 1)
+                tTick = 1;
+            iTickNext = (iTickNext * tTick) / 100;
+        }
+        else
+        {
+            iTickNext = (iTickNext * pCharDef->m_iMoveRate) / 100;
+        }
+        if (iTickNext < 1)
+            iTickNext = 1;
+
+        //_SetTimeout(iTickNext);
+        SetTimeout(iTickNext);
     }
+    else
+    {
+        // TAG.OVERRIDE.MOVERATE
+        int64 tTick;
+        CVarDefCont *pVal = GetKey("OVERRIDE.MOVEDELAY", true);
+        if (pVal)
+        {
+            iTickNext = pVal->GetValNum();                  // foot walking speed
+            if (IsStatFlag(STATF_ONHORSE | STATF_HOVERING)) // On Mount
+            {
+                if (IsStatFlag(STATF_FLY))                  // Running
+                {
+                    iTickNext /= 4;                         // 4 times faster when running while it's on a mount
+                }
+                else
+                {
+                    iTickNext /= 2; // 2 times faster when walking while it's on a mount
+                }
+            }
+            else
+            {
+                if (IsStatFlag(STATF_FLY))
+                {
+                    iTickNext /= 2; // 2 times faster when running.
+                }
+            }
+        }
+        else
+        {
+            CVarDefCont *pValue = GetKey("OVERRIDE.MOVERATE", true);
+            if (pValue)
+                tTick = pValue->GetValNum();   //Taking value from tag.override.moverate
+            else
+                tTick = pCharDef->m_iMoveRate; //no tag.override.moverate, we get default moverate (created from ini's one).
+            // END TAG.OVERRIDE.MOVERATE
+            if (fRun)
+            {
+                if (IsStatFlag(STATF_PET)) // pets run a little faster.
+                {
+                    if (iDex < 75)
+                        iDex = 75;
+                }
+                iTickNext = MSECS_PER_SEC / 4 + g_Rand.GetValFast(int32(100 - (iDex * tTick) / 100) / 5) * MSECS_PER_SEC /
+                                                    10; // TODO MSEC to TICK? custom timers for npc's movement?
+            }
+            else
+                iTickNext = MSECS_PER_SEC + g_Rand.GetValFast(int32(100 - (iDex * tTick) / 100) / 3) * MSECS_PER_SEC / 10;
+        }
 
-	if (iTickNext < MSECS_PER_TENTH) // Do not allow less than a tenth of second. This may be decreased in the future to allow more precise timers, at the cost of cpu.
-		iTickNext = MSECS_PER_TENTH;
-	else if (iTickNext > 5 * MSECS_PER_SEC)  // neither more than 5 seconds.
-		iTickNext = 5 * MSECS_PER_SEC;
+        if (iTickNext <
+            MSECS_PER_TENTH) // Do not allow less than a tenth of second. This may be decreased in the future to allow more precise timers, at the cost of cpu.
+            iTickNext = MSECS_PER_TENTH;
+        else if (iTickNext > 5 * MSECS_PER_SEC) // neither more than 5 seconds.
+            iTickNext = 5 * MSECS_PER_SEC;
 
-	_SetTimeout(iTickNext);
+        _SetTimeout(iTickNext);
+    }
+	
 	EXC_CATCH;
 	return 1;
 }

--- a/src/game/chars/CCharNotoriety.cpp
+++ b/src/game/chars/CCharNotoriety.cpp
@@ -186,7 +186,7 @@ NOTO_TYPE CChar::Noto_CalcFlag(const CChar * pCharViewer, bool fAllowIncog, bool
 				}
 			}
 
-			if (NPC_IsOwnedBy(pCharViewer, false))	// All pets are neutral to their owners.
+            if (!IsSetOF(OF_PetBehaviorOwnerNeutral) && NPC_IsOwnedBy(pCharViewer, false)) // All pets are neutral to their owners.
 				return NOTO_NEUTRAL;
 		}
 

--- a/src/sphere.ini
+++ b/src/sphere.ini
@@ -858,6 +858,7 @@ Experimental=0
 // OF_VendorStockLimit			01000000 // Limits how much of an item a vendor can buy using the value set in the TEMPLATE. Format: BUY=ID,AMOUNT
 // OF_EnableGuildAlignNotoriety		02000000 // If enabled, guilds with the same alignment will see each other as enemy or ally.
 // OF_PetBehaviorOwnerNeutral		04000000 // Should my pets always appear natural to me?
+// OF_NPCMovementOldStyle           06000000 // Required setting to make NPCs run like in the old version.
 OptionFlags=08|080|0200
 
 // Area flags

--- a/src/sphere.ini
+++ b/src/sphere.ini
@@ -857,6 +857,7 @@ Experimental=0
 // OF_AllowContainerInsideContainer	00800000 // Allow containers inside other containers even if they are heavier than the container being inserted into.
 // OF_VendorStockLimit			01000000 // Limits how much of an item a vendor can buy using the value set in the TEMPLATE. Format: BUY=ID,AMOUNT
 // OF_EnableGuildAlignNotoriety		02000000 // If enabled, guilds with the same alignment will see each other as enemy or ally.
+// OF_PetBehaviorOwnerNeutral		04000000 // Should my pets always appear natural to me?
 OptionFlags=08|080|0200
 
 // Area flags


### PR DESCRIPTION
If this setting is enabled, pets you own will appear to you with the original noto (old behavior). If this setting is not enabled, the assets you own will always appear natural to you. This setting only applies when the owning character is looking at the asset they own. It does not apply when someone else is looking at the asset you own.
