### PR TITLE
Logout trigger for NPCs

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3914,3 +3914,6 @@ Added: 'H' shortcut for variables to get the value as hexadecimal.
 
 13-10-2024, Jhobean
 - Added: @PetRelease trigger work like @petdesert and return 1 to prevent the pet from being released.
+
+25-10-2024, canerksk 
+- Added: @Logout trigger When NPCs (mounts) are logged out of the session in any way, i.e. mounted or minimised, they will log out (disconnect) but will not trigger.

--- a/src/game/chars/CChar.cpp
+++ b/src/game/chars/CChar.cpp
@@ -528,6 +528,14 @@ void CChar::SetDisconnected(CSector* pNewSector)
         GetClientActive()->GetNetState()->markReadClosed();
     }
 
+    if (m_pNPC && !g_Serv.IsLoading())
+    {
+        if (IsTrigUsed(TRIGGER_LOGOUT))
+        {
+            OnTrigger(CTRIG_LogOut, this, nullptr);
+        }
+    }
+
 	if (m_pPlayer)
 	{
 		m_pPlayer->_iTimeLastDisconnectedMs = CWorldGameTime::GetCurrentTime().GetTimeRaw();


### PR DESCRIPTION
@Logout trigger When NPCs (mounts) are logged out of the session in any way, i.e. mounted or minimised, they will log out (disconnect) but will not trigger.
