### PR TITLE
bank hear fix

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3914,3 +3914,6 @@ Added: 'H' shortcut for variables to get the value as hexadecimal.
 
 13-10-2024, Jhobean
 - Added: @PetRelease trigger work like @petdesert and return 1 to prevent the pet from being released.
+
+07-11-2024, canerksk
+- Fixed: If you are around an entity that you own and you are trying to open a bank next to a bank, the "bank" command is perceived as a pet command and the bank does not open. There is no problem when you type "bank" after mounting the mount, but "bank" does not work when you dismount. (Issue #1331)

--- a/src/game/clients/CClientEvent.cpp
+++ b/src/game/clients/CClientEvent.cpp
@@ -1988,6 +1988,15 @@ void CClient::Event_Talk_Common(lpctstr pszText)	// PC speech
             break;
 		}
        */
+        // NPC's with special key words ?
+        if (pChar->m_pNPC)
+        {
+            if (pChar->m_pNPC->m_Brain == NPCBRAIN_BANKER)
+            {
+                if (FindStrWord(pszText, "BANK") > 0)
+                    break;
+            }
+        }
 	}
 
 	if ( !pChar )


### PR DESCRIPTION
If you are around an entity that you own and you are trying to open a bank next to a bank, the "bank" command is perceived as a pet command and the bank does not open. There is no problem when you type "bank" after mounting the mount, but "bank" does not work when you dismount. (Issue #1331)

tested.