### PR TITLE
Chat crashfix

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3960,3 +3960,6 @@ Added: 'H' shortcut for variables to get the value as hexadecimal.
 	NOTE; 
 		1. If no ReflectDamage or ReduceDamage values ​​are entered, the system defaults to the Reactive Armor Effect value.
 		2. No damage amount can be less than 1.
+
+4-12-2024, canerksk
+- Fixed: Sphere crash troubleshooting if a player has no CHATNAME value and remove a channel

--- a/src/game/clients/CChatChanMember.cpp
+++ b/src/game/clients/CChatChanMember.cpp
@@ -197,7 +197,7 @@ lpctstr CChatChanMember::GetChatName() const
     ADDTOCALLSTACK("CChatChanMember::GetChatName");
     const CClient *pClient = GetClientActive();
 
-    if (pClient)
+    if (pClient && pClient->GetAccount() && !pClient->GetAccount()->m_sChatName.IsEmpty())
         return(pClient->GetAccount()->m_sChatName);
     return "";
 }


### PR DESCRIPTION
Issue #1212 

Sphere crash troubleshooting if a player has no CHATNAME value and remove a channel