### PR TITLE
Added new local variable in WOPSYSTEM LOCAL.WOPTalkMode and ini setti…

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3916,7 +3916,7 @@ Added: 'H' shortcut for variables to get the value as hexadecimal.
 - Added: @PetRelease trigger work like @petdesert and return 1 to prevent the pet from being released.
 
 27-11-2024, canerksk
-- Added: All skills that have a distance query have been adjusted to take the RANGE values ​​of that skill.
+- Added: All skills that have a distance query have been adjusted to take the RANGE values of that skill.
 	All skills to be used in RANGE;
 		BLACKSMITHING
 		MINING // It was added before.
@@ -3958,8 +3958,30 @@ Added: 'H' shortcut for variables to get the value as hexadecimal.
 	LOCAL.ReduceDamage (r/w) = Amount to be deducted from damage received
 	LOCAL.DamageType (r/w) = Type of damage received (Default: DAMAGE_FIXED andDAMAGE_REACTIVE)
 	NOTE; 
-		1. If no ReflectDamage or ReduceDamage values ​​are entered, the system defaults to the Reactive Armor Effect value.
+		1. If no ReflectDamage or ReduceDamage values are entered, the system defaults to the Reactive Armor Effect value.
 		2. No damage amount can be less than 1.
 
 4-12-2024, canerksk
-- Fixed: Sphere crash troubleshooting if a player has no CHATNAME value and remove a channel
+- Fixed: Sphere crash troubleshooting if a player has no CHATNAME value and remove a channel.
+
+6-12-2024, canerksk
+- Added: Added LOCAL.WOPTalkMode in @SpellCast trigger and ini setting WOPTalkMode.
+	In some clients, different operations can be performed in return for this, for example, if this talkmode went from sphere as TALKMODE SPELL, the operation is performed according to this incoming talk mode according to the client versions. Here, the possibility of changing the talkmode according to the client version used is given. By default, TALKMODE_SPELL
+	Default talk mode: TALKMODE_SPELL = 10
+	Sphere.ini;
+	WOPTalkMode=0/14
+	
+	Trigger;
+	@SpellCast
+	Local.WOPTalkMode=0/14
+	
+	TALKMODE_SAY        = 0 // A character speaking.
+	TALKMODE_SYSTEM     = 1 // Display as system prompt
+	TALKMODE_EMOTE      = 2 // *smiles* at object (client shortcut: :+space)
+	TALKMODE_ITEM       = 6 // text labeling an item. Preceeded by "You see"
+	TALKMODE_NOSCROLL   = 7 // As a status msg. Does not scroll (as reported by the packet guides)
+	TALKMODE_WHISPER    = 8 // Only those close can here. (client shortcut: ;+space)
+	TALKMODE_YELL       = 9 // Can be heard 2 screens away. (client shortcut: !+space)
+	TALKMODE_SPELL      = 10 // Used by spells
+	TALKMODE_GUILD      = 13 // Used by guild chat (client shortcut: \)
+	TALKMODE_ALLIANCE   = 14 // Used by alliance chat (client shortcut: shift+\)

--- a/src/game/CServerConfig.cpp
+++ b/src/game/CServerConfig.cpp
@@ -77,6 +77,7 @@ CServerConfig::CServerConfig()
 	m_iWordsOfPowerFont		= FONT_NORMAL;
 	m_fWordsOfPowerPlayer	= true;
 	m_fWordsOfPowerStaff	= false;
+    m_iWordsOfPowerTalkMode = TALKMODE_SPELL;
 	m_fEquippedCast			= true;
 	m_iMagicUnlockDoor		= 900;
 	m_iSpellTimeout			= 0;
@@ -732,6 +733,7 @@ enum RC_TYPE
 	RC_WOPFONT,
 	RC_WOPPLAYER,
 	RC_WOPSTAFF,
+	RC_WOPTALKMODE,
 	RC_WORLDSAVE,
 	RC_ZEROPOINT,				// m_sZeroPoint
 	RC_QTY
@@ -1025,6 +1027,7 @@ const CAssocReg CServerConfig::sm_szLoadKeys[RC_QTY + 1]
 	{ "WOPFONT",				{ ELEM_INT,		static_cast<uint>OFFSETOF(CServerConfig,m_iWordsOfPowerFont)		}},
 	{ "WOPPLAYER",				{ ELEM_BOOL,	static_cast<uint>OFFSETOF(CServerConfig,m_fWordsOfPowerPlayer)	}},
 	{ "WOPSTAFF",				{ ELEM_BOOL,	static_cast<uint>OFFSETOF(CServerConfig,m_fWordsOfPowerStaff)	}},
+    { "WOPTALKMODE",            { ELEM_INT,     static_cast<uint>OFFSETOF(CServerConfig,m_iWordsOfPowerTalkMode) }},
 	{ "WORLDSAVE",				{ ELEM_CSTRING,	static_cast<uint>OFFSETOF(CServerConfig,m_sWorldBaseDir)			}},
 	{ "ZEROPOINT",				{ ELEM_CSTRING,	static_cast<uint>OFFSETOF(CServerConfig,m_sZeroPoint)			}},
 	{ nullptr,					{ ELEM_VOID,	0,												}}

--- a/src/game/CServerConfig.h
+++ b/src/game/CServerConfig.h
@@ -303,6 +303,7 @@ public:
 	int  m_iWordsOfPowerFont;   // Font used for Words Of Power.
 	bool m_fWordsOfPowerPlayer; // Words of Power for players.
 	bool m_fWordsOfPowerStaff;  // Words of Power for staff.
+    TALKMODE_TYPE m_iWordsOfPowerTalkMode; // Walk mode used for Words Of Power.
 	bool m_fEquippedCast;       // Allow casting while equipped.
     bool m_fManaLossAbort;      // Lose mana when spell casting aborted.
     bool m_fManaLossFail;       // Lose mana when spell casting failed.

--- a/src/game/chars/CCharSpell.cpp
+++ b/src/game/chars/CCharSpell.cpp
@@ -3486,6 +3486,11 @@ int CChar::Spell_CastStart()
 	Args.m_VarsLocal.SetNum("WOP", fWOP);
 	int64 WOPFont = g_Cfg.m_iWordsOfPowerFont;
 	int64 WOPColor;
+    TALKMODE_TYPE WOPTalkMode = g_Cfg.m_iWordsOfPowerTalkMode ? g_Cfg.m_iWordsOfPowerTalkMode : TALKMODE_SPELL;
+
+    if (WOPTalkMode < TALKMODE_SAY || WOPTalkMode >= TALKMODE_COMMAND)
+        WOPTalkMode = TALKMODE_SPELL;
+
 	if (g_Cfg.m_iWordsOfPowerColor > 0)
 		WOPColor = g_Cfg.m_iWordsOfPowerColor;
 	else if (m_SpeechHueOverride)
@@ -3494,8 +3499,10 @@ int CChar::Spell_CastStart()
 		WOPColor = m_pPlayer->m_SpeechHue;
     else
         WOPColor = HUE_TEXT_DEF;
+
 	Args.m_VarsLocal.SetNum("WOPColor", WOPColor, true);
 	Args.m_VarsLocal.SetNum("WOPFont", WOPFont, true);
+    Args.m_VarsLocal.SetNum("WOPTalkMode", WOPTalkMode, true);
 
 	if ( IsTrigUsed(TRIGGER_SPELLCAST) )
 	{
@@ -3540,11 +3547,12 @@ int CChar::Spell_CastStart()
 	{
 		WOPColor = Args.m_VarsLocal.GetKeyNum("WOPColor");
 		WOPFont = Args.m_VarsLocal.GetKeyNum("WOPFont");
+        WOPTalkMode = (TALKMODE_TYPE)Args.m_VarsLocal.GetKeyNum("WOPTalkMode");
 
 		// Correct talk mode for spells WOP is TALKMODE_SPELL, but sphere doesn't have any delay between spell casts this can allow WOP flood on screen.
 		if ( pSpellDef->m_sRunes[0] == '.' )
 		{
-			Speak((pSpellDef->m_sRunes.GetBuffer()) + 1, (HUE_TYPE)WOPColor, TALKMODE_SPELL, (FONT_TYPE)WOPFont);
+            Speak((pSpellDef->m_sRunes.GetBuffer()) + 1, (HUE_TYPE)WOPColor, (TALKMODE_TYPE)WOPTalkMode, (FONT_TYPE)WOPFont);
 		}
 		else
 		{
@@ -3562,7 +3570,7 @@ int CChar::Spell_CastStart()
 			if ( len > 0 )
 			{
 				pszTemp[len] = 0;
-				Speak(pszTemp, (HUE_TYPE)WOPColor, TALKMODE_SPELL, (FONT_TYPE)WOPFont);
+                Speak(pszTemp, (HUE_TYPE)WOPColor, (TALKMODE_TYPE)WOPTalkMode, (FONT_TYPE)WOPFont);
 			}
 		}
 	}

--- a/src/sphere.ini
+++ b/src/sphere.ini
@@ -1006,6 +1006,19 @@ WOPStaff=0
 // Words of power color (0 = inherit color from char SPEECHCOLOR value)
 //WOPColor=03b2
 
+// TALKMODE_SAY        = 0 // A character speaking.
+// TALKMODE_SYSTEM     = 1 // Display as system prompt
+// TALKMODE_EMOTE      = 2 // *smiles* at object (client shortcut: :+space)
+// TALKMODE_ITEM       = 6 // text labeling an item. Preceeded by "You see"
+// TALKMODE_NOSCROLL   = 7 // As a status msg. Does not scroll (as reported by the packet guides)
+// TALKMODE_WHISPER    = 8 // Only those close can here. (client shortcut: ;+space)
+// TALKMODE_YELL       = 9 // Can be heard 2 screens away. (client shortcut: !+space)
+// TALKMODE_SPELL      = 10 // Used by spells
+// TALKMODE_GUILD      = 13 // Used by guild chat (client shortcut: \)
+// TALKMODE_ALLIANCE   = 14 // Used by alliance chat (client shortcut: shift+\)
+// Words of power talk mode (Default: 10 = TALKMODE_SPELL)
+WOPTalkMode=1
+
 // Mana lost when casting spell action fails or abort
 ManaLossAbort=0		// Lose Mana when the spell is aborted during spell casting.
 ManaLossFail=0		// Lose Mana when the spell is failed during the spell casting.


### PR DESCRIPTION
…ngs WOPTalkMode (#1325)

* Added new local variable in WOPSYSTEM LOCAL.WOPTalkMode and ini settings WOPTalkMode

	In some clients, different operations can be performed in return for this, for example, if this talkmode went from sphere as TALKMODE SPELL, the operation is performed according to this incoming talk mode according to the client versions. Here, the possibility of changing the talkmode according to the client version used is given. By default, TALKMODE_SPELL
	Default talk mode: TALKMODE_SPELL = 10
	Sphere.ini;
	WOPTalkMode=0/14

	Trigger;
	@SpellCast
	Local.WOPTalkMode=0/14

Tested.

* initialize the new member variable in the cserverconfig

---------