### PR TITLE
Reset Item Link when set empty

### DIFF
--- a/src/game/items/CItem.cpp
+++ b/src/game/items/CItem.cpp
@@ -3342,7 +3342,17 @@ bool CItem::r_LoadVal( CScript & s ) // Load an item Script
 			SetUnkZ( s.GetArgCVal() ); // GetEquipLayer()
             break;
 		case IC_LINK:
-			m_uidLink.SetObjUID(s.GetArgDWVal());
+			{
+                CUID uidLink = (CUID)s.GetArgDWVal();
+                if ((dword)uidLink == 0)
+                {
+                    m_uidLink.InitUID();
+                }
+                else
+                {
+                    m_uidLink.SetObjUID(uidLink);
+                }
+            }
             break;
 
 		case IC_FRUIT:	// m_more2


### PR DESCRIPTION
In this way you don't have to set Link=04fffffff when you want to remove a link from an item.
You just do Link=