### PR TITLE
Add a warning line when an item is delete on save

### DIFF
--- a/src/game/CWorld.cpp
+++ b/src/game/CWorld.cpp
@@ -502,6 +502,7 @@ int CWorldThread::FixObj( CObjBase * pObj, dword dwUID )
 			CItem * pItem = dynamic_cast <CItem*>(pObj);
 			if ( pItem != nullptr && pItem->IsType(IT_EQ_MEMORY_OBJ) )
 			{
+                ReportGarbageCollection(pObj, iResultCode);
 				pObj->Delete();
 				return iResultCode;
 			}


### PR DESCRIPTION
On some situation, I had a i_memory deleted on save because there was no color on the i_mem!!!

No warning and nothing!  After 2 hour of debug, I found what was happen and it was missing a log error.

With this line of code the error now appear on log.
![image](https://github.com/user-attachments/assets/20a6c1b2-1a88-4939-a052-d8b4dee954b6)
