### PR TITLE
src/common/CScriptObj: do not declare `environ` on Windows

### DIFF
--- a/src/common/CScriptObj.cpp
+++ b/src/common/CScriptObj.cpp
@@ -31,7 +31,7 @@
 #   include <spawn.h> // for posix_spawn()
 #endif
 
-#ifndef __GLIBC__
+#if !defined(_WIN32) && !defined(__GLIBC__)
 extern char **environ;
 #endif
 


### PR DESCRIPTION
It's only used on non-Windows OSes, and declaring it on all but glibc broke the Windows build.  Fixes regression by commit 2a129d5683ab0