### PR TITLE
.github/workflows/build*: pass "-v" to ninja

### DIFF
--- a/.github/workflows/build_linux_x86.yml
+++ b/.github/workflows/build_linux_x86.yml
@@ -102,7 +102,7 @@ jobs:
               -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -S ./ -B ./build
     - name: Ninja
-      run: ninja -C build
+      run: ninja -C build -v
     - name: Create package
       run:  |
             mkdir accounts logs save scripts

--- a/.github/workflows/build_linux_x86.yml
+++ b/.github/workflows/build_linux_x86.yml
@@ -103,6 +103,8 @@ jobs:
             cmake -G "Ninja" -DCMAKE_BUILD_TYPE="Nightly" \
               -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/Linux-GNU-x86.cmake \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+              -DCMAKE_C_FLAGS="-fpch-preprocess" \
+              -DCMAKE_CXX_FLAGS="-fpch-preprocess" \
               -S ./ -B ./build
     - name: Ninja
       run: ninja -C build -v

--- a/.github/workflows/build_linux_x86.yml
+++ b/.github/workflows/build_linux_x86.yml
@@ -88,6 +88,9 @@ jobs:
       with:
         key: ${{github.job}}
 
+    - name: Configure ccache
+      run:  ccache --set-config sloppiness="include_file_mtime, include_file_ctime, time_macros, pch_defines"
+
     - name: Report building tools
       run:  |
             echo "GCC:" && gcc -v

--- a/.github/workflows/build_linux_x86_64.yml
+++ b/.github/workflows/build_linux_x86_64.yml
@@ -58,6 +58,8 @@ jobs:
             cmake -G "Ninja" -DCMAKE_BUILD_TYPE="Nightly" \
               -DCMAKE_TOOLCHAIN_FILE=cmake/toolchains/Linux-GNU-x86_64.cmake \
               -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+              -DCMAKE_C_FLAGS="-fpch-preprocess" \
+              -DCMAKE_CXX_FLAGS="-fpch-preprocess" \
               -S ./ -B ./build
     - name: Ninja
       run: ninja -C build -v

--- a/.github/workflows/build_linux_x86_64.yml
+++ b/.github/workflows/build_linux_x86_64.yml
@@ -57,7 +57,7 @@ jobs:
               -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
               -S ./ -B ./build
     - name: Ninja
-      run: ninja -C build
+      run: ninja -C build -v
     - name: Create package
       run:  |
             mkdir accounts logs save scripts

--- a/.github/workflows/build_linux_x86_64.yml
+++ b/.github/workflows/build_linux_x86_64.yml
@@ -43,6 +43,9 @@ jobs:
       with:
         key: ${{github.job}}
 
+    - name: Configure ccache
+      run:  ccache --set-config sloppiness="include_file_mtime, include_file_ctime, time_macros, pch_defines"
+
     - name: Report building tools
       run:  |
             echo "GCC:" && gcc -v

--- a/.github/workflows/build_osx_arm.yml
+++ b/.github/workflows/build_osx_arm.yml
@@ -51,7 +51,7 @@ jobs:
             mkdir -p build
             cmake -G "Ninja" -DCMAKE_BUILD_TYPE="Nightly" -DCMAKE_TOOLCHAIN_FILE="$CMAKE_TCH" -S . -B ./build
     - name: Ninja
-      run: ninja -C build
+      run: ninja -C build -v
     - name: Create package
       run:  |
             pwd

--- a/.github/workflows/build_osx_x86_64.yml
+++ b/.github/workflows/build_osx_x86_64.yml
@@ -49,7 +49,7 @@ jobs:
             mkdir -p build
             cmake -G "Ninja" -DCMAKE_BUILD_TYPE="Nightly" -DCMAKE_TOOLCHAIN_FILE="$CMAKE_TCH" -S . -B ./build
     - name: Ninja
-      run: ninja -C build
+      run: ninja -C build -v
     - name: Create package
       run:  |
             pwd


### PR DESCRIPTION
The CI log should be verbose so we can see what commands are really being used, and it's pointless to use the default "beautified" ninja output.  In this case, I'd like to know why my ccache changes were not used ("Hits: 0 / Uncacheable: 210"), see commit b06a46ebba1edfef