### PR TITLE
cmake: link with `--gc-sections`

### DIFF
--- a/cmake/CompilerFlagsBase.cmake
+++ b/cmake/CompilerFlagsBase.cmake
@@ -1,3 +1,4 @@
+include(CheckLinkerFlag)
 message(STATUS "Setting base compiler flags...")
 
 if(NOT MSVC)
@@ -49,6 +50,11 @@ if(NOT MSVC)
         # Probably useful when using lto: -ffunction-sections -fdata-sections
         set(local_compile_options_nondebug -O3)# -flto)
         set(local_link_options_nondebug)#-flto)
+    endif()
+
+    check_linker_flag(CXX -Wl,--gc-sections LINKER_HAS_GC_SECTIONS)
+    if(LINKER_HAS_GC_SECTIONS)
+      list(APPEND local_link_options_nondebug -Wl,--gc-sections)
     endif()
 
     set(custom_compile_options_release

--- a/cmake/CompilerFlagsChecker.cmake
+++ b/cmake/CompilerFlagsChecker.cmake
@@ -17,6 +17,7 @@ if(NOT MSVC)
     #check_cxx_compiler_flag("" COMP_HAS_)
 
     # Compiler option flags. Expected to work on GCC but not Clang, at the moment.
+    check_cxx_compiler_flag("-fvisibility=hidden" COMP_HAS_FVISIBILITY_HIDDEN)
     check_cxx_compiler_flag("-fno-expensive-optimizations" COMP_HAS_FNO_EXPENSIVE_OPTIMIZATIONS)
 
     # Compiler option flags. Expected to work on Clang but not GCC, at the moment.
@@ -204,6 +205,10 @@ if(NOT MSVC)
     #if(COMP_HAS_LTO)
     #    list(APPEND checked_compiler_options "-flto")
     #endif()
+
+    if(COMP_HAS_FVISIBILITY_HIDDEN)
+        list(APPEND checked_compiler_options "-fvisibility=hidden")
+    endif()
 
     if(COMP_HAS_FNO_EXPENSIVE_OPTIMIZATIONS)
         list(APPEND checked_compiler_options "-fno-expensive-optimizations")


### PR DESCRIPTION
This linker flag, if supported, removes unused sections from the
executable.  Unused sections are those that do not contain public
symbols (therefore `-fvisibility=hidden`) and are not referenced by
other sections.

This shrinks the code size by 4%:
```
    text	  data	   bss	   dec	   hex	filename
 4069421	285904	1427713	5783038	583dfe	Debug/bin-native64/SphereSvrX64_release
 3918858	284456	1427713	5631027	55ec33	Debug/bin-native64/SphereSvrX64_release
```