### PR TITLE
Fixed: spiderwebs accumulating in sleeping sector (Issue #1249)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -3989,7 +3989,7 @@ Added: 'H' shortcut for variables to get the value as hexadecimal.
 08-01-2025, DavideRei
 - Fixed: NPC FLEE action didn't work because it was using action target (empty) instead of fight target
 
-28-02-2025 (dev), canerksk
+28-02-2025, canerksk
 - Added: Add OpenDoorMacro and World Search Distance as Local Variables to @UserExtCmd Trigger
 	LOCAL.DoorAutoDist <distance> (R/W). Default Distance = 2.
 	eg;
@@ -3999,3 +3999,7 @@ Added: 'H' shortcut for variables to get the value as hexadecimal.
 
 28-02-2025, cbnolok
 - Fixed: failing assertion if targeting a non-corpse object when casting Animate Dead spell.
+
+05-03-2025, cbnolok
+- Fixed: If Giant Spiders and Fire Elementals are denied going into sleeping state into a sleeping sector, their dropped items (ie. i_spider_web) went into sleeping state and didn't decay, leading to accumulation (Issue #1249).
+  Also, stamina wasn't consumed, thus NPCs had no limit in placing those items.

--- a/src/game/chars/CCharAct.cpp
+++ b/src/game/chars/CCharAct.cpp
@@ -5822,21 +5822,30 @@ bool CChar::_OnTick()
     EXC_TRY("Tick");
 
 	EXC_SET_BLOCK("Can Tick?");
-	if ((_IsSleeping() || IsDisconnected()) && (Skill_GetActive() != NPCACT_RIDDEN))
+
+    if ((_IsSleeping() || IsDisconnected()) && (Skill_GetActive() != NPCACT_RIDDEN))
 	{
 		// mounted horses can still get a tick.
 		return true;
 	}
-	if (!_CanTick())
+    if (!_CanTick())
 	{
+        // It can happen that i'm in the ticking list, but for various reasons right now i'm in a non-tickable state.
+        // Among the reasons why i can't tick, though, there cannot be being in a sleeping state: when a char goes into sleeping state
+        //  it should also be removed from the list (it happens in _GoSleep()).
 		ASSERT(!_IsSleeping());
+
 		if (GetTopSector()->IsSleeping() && !g_Rand.Get16ValFast(15))
 		{
+            // Do not make the char sleep right when it enters a sleeping sector. Doing this
+            //  will lead to an accumulation of npcs at the edge of the new sector.
+
 			_SetTimeout(1);      //Make it tick after sector's awakening.
 			_GoSleep();
 			return true;
 		}
 	}
+    ASSERT(!_IsSleeping());
 
 	EXC_SET_BLOCK("Components Tick");
 	/*

--- a/src/game/chars/CCharNPCAct.cpp
+++ b/src/game/chars/CCharNPCAct.cpp
@@ -87,7 +87,9 @@ void CChar::Action_StartSpecial( CREID_TYPE id )
 			pItem->m_itSpell.m_spelllevel = (word)(100 + g_Rand.Get16ValFast(500));
 			pItem->m_itSpell.m_spellcharges = 1;
 			pItem->m_uidLink = GetUID();
-			pItem->MoveToDecay( GetTopPoint(), 10 + g_Rand.Get16ValFast(50)*MSECS_PER_SEC);
+            const bool fPlaced = pItem->MoveToDecay( GetTopPoint(), 10 + g_Rand.Get16ValFast(50)*MSECS_PER_SEC);
+            if (fPlaced && Can(CAN_O_NOSLEEP))
+                pItem->m_CanMask |= CAN_O_NOSLEEP;
 		}
 		break;
 
@@ -97,16 +99,19 @@ void CChar::Action_StartSpecial( CREID_TYPE id )
 			CItem * pItem = CItem::CreateScript( (ITEMID_TYPE)(g_Rand.GetVal2Fast(ITEMID_WEB1_1, ITEMID_WEB1_4)), this );
 			ASSERT(pItem);
 			pItem->SetType(IT_WEB);
-			pItem->MoveToDecay( GetTopPoint(), 10 + g_Rand.Get16ValFast(170)*MSECS_PER_SEC);
+            const bool fPlaced = pItem->MoveToDecay( GetTopPoint(), 10 + g_Rand.Get16ValFast(170)*MSECS_PER_SEC);
+            if (fPlaced && Can(CAN_O_NOSLEEP))
+                pItem->m_CanMask |= CAN_O_NOSLEEP;
 		}
 		break;
 
 		default:
-			SysMessage( "You have no special abilities" );
+            ASSERT(false);
+            //SysMessage( "You have no special abilities" );
 			return;
 	}
 
-	UpdateStatVal( STAT_DEX, (ushort)(-(5 + g_Rand.Get16ValFast(5)) ));	// the stamina cost
+    UpdateStatVal( STAT_DEX, -(5 + g_Rand.Get16ValFast(5)) );	// the stamina cost
 }
 
 bool CChar::NPC_OnVerb( CScript &s, CTextConsole * pSrc ) // Execute command from script
@@ -1951,7 +1956,9 @@ void CChar::NPC_Act_Idle()
 						Action_StartSpecial(CREID_GIANT_SPIDER);
 						return;
 					}
-				} else {
+                }
+                else
+                {
 					if ( GetDispID() == CREID_GIANT_SPIDER )
 					{
 						Action_StartSpecial(CREID_GIANT_SPIDER);


### PR DESCRIPTION
Fixed: If Giant Spiders and Fire Elementals are denied going into sleeping state into a sleeping sector, their dropped items (ie. i_spider_web) went into sleeping state and didn't decay, leading to accumulation (Issue #1249).
  Also, stamina wasn't consumed, thus NPCs had no limit in placing those
items.