### PR TITLE
Added new ini option to display more bounce messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.cache
 /.git
 /.vscode
+/.idea
 *.vshistory*
 /.kdev*
 /.ctagsd
@@ -49,7 +50,6 @@
 *.*project
 *.*workspace
 *.kdev*
-
 
 # Ignore some files in the parent folder
 CMakeCache.txt

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4011,4 +4011,7 @@ Added: 'H' shortcut for variables to get the value as hexadecimal.
 - Fixed: when using the ini setting ItemTimers=1 (enabling items to tick even if inside a container), the items kept ticking even after a char logout.
 - Fixed: when using the ini setting ItemTimers=1, items ticked on npcs ridden by a disconnected char.
 
-
+18-04-2025, Mulambo
+- Added ini settings:
+	// Display more bounce messages when drinking potions, fishing, crafting etc. (Old sphere behaviour).
+    VerboseItemBounce=0

--- a/src/game/CServerConfig.cpp
+++ b/src/game/CServerConfig.cpp
@@ -202,6 +202,7 @@ CServerConfig::CServerConfig()
 	m_fDisplayPercentAr = false;
 	m_fDisplayElementalResistance = false;
 	m_fNoResRobe		= 0;
+    m_iBounceMessage        = false;
 	m_iLostNPCTeleport	= 50;
 	m_iAutoProcessPriority = 0;
 	m_iDistanceYell		= UO_MAP_VIEW_RADAR;
@@ -725,6 +726,7 @@ enum RC_TYPE
 	RC_VENDORMARKUP,			// m_iVendorMarkup
 	RC_VENDORMAXSELL,			// m_iVendorMaxSell
 	RC_VENDORTRADETITLE,		// m_fVendorTradeTitle
+	RC_VERBOSEITEMBOUNCE,		// m_iBounceMessage
 	RC_VERSION,
 	RC_WALKBUFFER,
 	RC_WALKREGEN,
@@ -1019,6 +1021,7 @@ const CAssocReg CServerConfig::sm_szLoadKeys[RC_QTY + 1]
 	{ "VENDORMARKUP",			{ ELEM_INT,		static_cast<uint>OFFSETOF(CServerConfig,m_iVendorMarkup)			}},
 	{ "VENDORMAXSELL",			{ ELEM_INT,		static_cast<uint>OFFSETOF(CServerConfig,m_iVendorMaxSell)		}},
 	{ "VENDORTRADETITLE",		{ ELEM_BOOL,	static_cast<uint>OFFSETOF(CServerConfig,m_fVendorTradeTitle)		}},
+	{ "VERBOSEITEMBOUNCE",		{ ELEM_BOOL,	static_cast<uint>OFFSETOF(CServerConfig,m_iBounceMessage)		}},
 	{ "VERSION",				{ ELEM_VOID,	0												}},
 	{ "WALKBUFFER",				{ ELEM_INT,		static_cast<uint>OFFSETOF(CServerConfig,m_iWalkBuffer)			}},
 	{ "WALKREGEN",				{ ELEM_INT,		static_cast<uint>OFFSETOF(CServerConfig,m_iWalkRegen)			}},

--- a/src/game/CServerConfig.h
+++ b/src/game/CServerConfig.h
@@ -411,6 +411,7 @@ public:
 	uint _uiOptionFlags;		// Option Flags.
     uint _uiAreaFlags;		    // Area Flags.
     bool m_fNoResRobe;          // Adding resurrection robe to resurrected players or not.
+    bool m_iBounceMessage;      // Display more item bounce messages.
     int	 m_iLostNPCTeleport;    // if Distance from HOME is greater than this, NPC will teleport to it instead of walking.
 	int64 m_iWoolGrowthTime;    // how long till wool grows back on sheared sheep, in minutes (stored as milliseconds).
 	int  m_iAttackerTimeout;    // Timeout for an attacker  (stored in seconds, not in milliseconds).

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -2196,7 +2196,7 @@ WAR_SWING_TYPE CChar::Fight_Hit( CChar * pCharTarg )
 		if ( pCharTarg->m_pNPC && (40 >= g_Rand.Get16ValFast(100)) )
 		{
 			pAmmo->UnStackSplit(1);
-			pCharTarg->ItemBounce(pAmmo, false);
+			pCharTarg->ItemBounce(pAmmo, g_Cfg.m_iBounceMessage);
 		}
 		else
 			pAmmo->ConsumeAmount(1);

--- a/src/game/chars/CCharNPCAct.cpp
+++ b/src/game/chars/CCharNPCAct.cpp
@@ -1599,7 +1599,7 @@ void CChar::NPC_Act_Looting()
 	if ( pCorpse )
 		Speak(g_Cfg.GetDefaultMsg(DEFMSG_LOOT_RUMMAGE), HUE_TEXT_DEF, TALKMODE_EMOTE);
 
-	ItemBounce(pItem, false);
+	ItemBounce(pItem, g_Cfg.m_iBounceMessage);
     UpdateAnimate(ANIM_PILLAGE);
     SetTimeout(1000);
 }
@@ -2696,7 +2696,7 @@ void CChar::NPC_ExtraAI()
 	{
 		CItem *pLightSource = LayerFind(LAYER_HAND2);
 		if ( pLightSource && (pLightSource->IsType(IT_LIGHT_OUT) || pLightSource->IsType(IT_LIGHT_LIT)) )
-			ItemBounce(pLightSource, false);
+			ItemBounce(pLightSource, g_Cfg.m_iBounceMessage);
 	}
 
 	EXC_CATCH;

--- a/src/game/chars/CCharSkill.cpp
+++ b/src/game/chars/CCharSkill.cpp
@@ -697,7 +697,7 @@ bool CChar::Skill_MakeItem_Success()
 			for ( uint n = 1; n < m_atCreate.m_dwAmount; ++n )
 			{
 				CItem *ptItem = CItem::CreateTemplate(m_atCreate.m_iItemID, nullptr, this);
-				ItemBounce(ptItem, false);
+				ItemBounce(ptItem, g_Cfg.m_iBounceMessage);
 			}
 		}
 	}
@@ -1572,7 +1572,7 @@ int CChar::Skill_Fishing( SKTRIG_TYPE stage )
         }
         SysMessagef(g_Cfg.GetDefaultMsg(DEFMSG_FISHING_SUCCESS), pItem->GetName());
         if (m_atResource.m_dwBounceItem)
-            ItemBounce(pItem, false);
+            ItemBounce(pItem, g_Cfg.m_iBounceMessage);
         else
             pItem->MoveToCheck(GetTopPoint(), this);	// put at my feet.
         return 0;

--- a/src/game/chars/CCharSpell.cpp
+++ b/src/game/chars/CCharSpell.cpp
@@ -3089,7 +3089,7 @@ bool CChar::Spell_CastDone()
 				}
 				else
 				{
-					ItemBounce(pItem, false);
+					ItemBounce(pItem, g_Cfg.m_iBounceMessage);
 					SysMessagef(g_Cfg.GetDefaultMsg(DEFMSG_SPELL_CREATE_FOOD), pItem->GetName());
 				}
 			}

--- a/src/game/chars/CCharStat.cpp
+++ b/src/game/chars/CCharStat.cpp
@@ -797,7 +797,7 @@ void CChar::Stat_StrCheckEquip()
 		if (!CanEquipStr(pItem))
 		{
 			SysMessagef("%s %s.", g_Cfg.GetDefaultMsg(DEFMSG_EQUIP_NOT_STRONG_ENOUGH), pItem->GetName());
-			ItemBounce(pItem, false);
+			ItemBounce(pItem, g_Cfg.m_iBounceMessage);
 		}
 	}
 }

--- a/src/game/chars/CCharUse.cpp
+++ b/src/game/chars/CCharUse.cpp
@@ -462,7 +462,7 @@ bool CChar::Use_Train_ArcheryButte( CItem * pButte, bool fSetup )
 		CItem *pRemovedAmmo = CItem::CreateBase((ITEMID_TYPE)pButte->m_itArcheryButte.m_ridAmmoType.GetResIndex());
 		ASSERT(pRemovedAmmo);
 		pRemovedAmmo->SetAmount((word)pButte->m_itArcheryButte.m_iAmmoCount);
-		ItemBounce(pRemovedAmmo, false);
+		ItemBounce(pRemovedAmmo, g_Cfg.m_iBounceMessage);
 		SysMessageDefault(DEFMSG_ITEMUSE_ARCHBUTTE_GATHER);
 
 		pButte->m_itArcheryButte.m_ridAmmoType.Clear();
@@ -1104,7 +1104,7 @@ void CChar::Use_Drink( CItem * pItem )
         if (wBottleAmount > 0)
         {
             pBottle->SetAmount(wBottleAmount);
-            ItemBounce(pBottle, false);
+            ItemBounce(pBottle, g_Cfg.m_iBounceMessage);
         }
     }
 }

--- a/src/game/items/CItem.cpp
+++ b/src/game/items/CItem.cpp
@@ -1007,7 +1007,7 @@ int CItem::FixWeirdness()
 						for (CSObjContRec* pObjRec : pTradeCont->GetIterationSafeContReverse())
 						{
 							CItem* pItem = static_cast<CItem*>(pObjRec);
-                            pCharCont->ItemBounce(pItem, false);
+                            pCharCont->ItemBounce(pItem, g_Cfg.m_iBounceMessage);
                         }
                     }
                 }

--- a/src/game/items/CItemContainer.cpp
+++ b/src/game/items/CItemContainer.cpp
@@ -187,13 +187,13 @@ void CItemContainer::Trade_Status( bool bCheck )
 	for (CSObjContRec* pObjRec : pPartner->GetIterationSafeContReverse())
 	{
 		CItem* pItem = static_cast<CItem*>(pObjRec);
-		pChar1->ItemBounce(pItem, false);
+		pChar1->ItemBounce(pItem, g_Cfg.m_iBounceMessage);
 	}
 
 	for (CSObjContRec* pObjRec : GetIterationSafeContReverse())
 	{
 		CItem* pItem = static_cast<CItem*>(pObjRec);
-		pChar2->ItemBounce(pItem, false);
+		pChar2->ItemBounce(pItem, g_Cfg.m_iBounceMessage);
 	}
 
 	// Transfer gold/platinum
@@ -304,7 +304,7 @@ bool CItemContainer::Trade_Delete()
 	for (CSObjContRec* pObjRec : GetIterationSafeContReverse())
 	{
 		CItem* pItem = static_cast<CItem*>(pObjRec);
-		pChar->ItemBounce(pItem, false);
+		pChar->ItemBounce(pItem, g_Cfg.m_iBounceMessage);
 	}
 
 	// Kill my trading partner.

--- a/src/sphere.ini
+++ b/src/sphere.ini
@@ -597,6 +597,9 @@ FlipDroppedItems=0
 // Max amount allowed for stackable items (can't be higher than 65535)
 ItemsMaxAmount=60000
 
+// Display more bounce messages when drinking potions, fishing, crafting etc. (Old sphere behaviour).
+VerboseItemBounce=0
+
 // Set to 1 to allow players to take equipment from their pets' paperdoll
 CanUndressPets=1
 


### PR DESCRIPTION
Some of the bounce messages were disabled, so the output wouldn't be too verbose, but it could be useful to be able to display them (for example when drinking potion / alcohol, that creates something different other than empty bottle).