### PR TITLE
Add command line switch for changing ini path (#1400)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4018,8 +4018,14 @@ Added: 'H' shortcut for variables to get the value as hexadecimal.
 	// Display more bounce messages when drinking potions, fishing, crafting etc. (Old sphere behaviour).
     VerboseItemBounce=0
 
-22-04-2024, canerksk
+22-04-2025, canerksk
 - Added: New item function, CARVECORPSE: carves a corpse with SRC = char carving the corpse. 
 - Added: New ini RevealFlag setting REVEALF_ONHORSE, to allow or disallow stealth walking if you are on a mount.
 - Added: new ini CombatFlags setting COMBAT_ATTACK_NOAGGREIVED.
 	In the old behavior (55i/55r/56b/56c) we were not guilty when we hit a murderer. Now when we attack a criminal or murderer we are guilty towards that person. An ini setting option has been added for this behavior. Although this is a normal behavior in OSI, it can be perceived as a problem since not every server designs games like OSI.
+
+29-04-2025, Mulambo
+- Added: new command line switch `-I=/path/to/ini/`
+    Allows you to define path to folder with ini files. Usable, when you want to separate binary from configuration or when running Sphere as Windows service (since services are usually run in C:\Windows\System32).
+    Usage: Linux: `.\SphereSvrX64_debug -I=/etc/sphereserver/`, Windows: `SphereSvrX64_nightly.exe -I=C:/sphere/` (trailing slash required).
+    Warning: if you want to use different folder for ini files, you need to replace paths in your sphere.ini and spheretables.scp with absolute paths!

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4039,7 +4039,7 @@ Added: 'H' shortcut for variables to get the value as hexadecimal.
 - Fixed: spell or skill defname reading from an object property.
 When setting a property like MORE to the a spell or skill defname, trying to read it returned back the resource index (like the spell number) instead of the defname (Issue #1397)
 
-29-04-2025, Mulambo
+05-05-2025, Mulambo
 - Added: new command line switch `-I=/path/to/ini/`
     Allows you to define path to folder with ini files. Usable, when you want to separate binary from configuration or when running Sphere as Windows service (since services are usually run in C:\Windows\System32).
     Usage: Linux: `.\SphereSvrX64_debug -I=/etc/sphereserver/`, Windows: `SphereSvrX64_nightly.exe -I=C:/sphere/` (trailing slash required).

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4043,4 +4043,3 @@ When setting a property like MORE to the a spell or skill defname, trying to rea
 - Added: new command line switch `-I=/path/to/ini/`
     Allows you to define path to folder with ini files. Usable, when you want to separate binary from configuration or when running Sphere as Windows service (since services are usually run in C:\Windows\System32).
     Usage: Linux: `.\SphereSvrX64_debug -I=/etc/sphereserver/`, Windows: `SphereSvrX64_nightly.exe -I=C:/sphere/` (trailing slash required).
-    Warning: if you want to use different folder for ini files, you need to replace paths in your sphere.ini and spheretables.scp with absolute paths!

--- a/src/game/CServer.cpp
+++ b/src/game/CServer.cpp
@@ -2305,6 +2305,7 @@ bool CServer::CommandLinePreLoad( int argc, tchar * argv[] )
                     "-E Enable the CrashDumper.\n"
 #endif
                     "-Gpath/to/saves/ Defrags sphere saves.\n"
+					"-I /path/to/ini/ Directory with ini files.\n"
 #ifdef _WIN32
                     "-K install/remove Installs or removes NT Service.\n"
                     "-J automatically close the console window at server termination.\n"
@@ -2410,7 +2411,7 @@ bool CServer::CommandLinePostLoad( int argc, tchar * argv[] )
                         if ( pCont != nullptr )
                             FileResDefs.Printf( "%s=%s\n", pCont->GetKey(), pCont->GetValStr());
                         ++i;
-            }
+                    }
 				}
 				continue;
 #if defined(_WIN32) && !defined(_DEBUG) && defined(WINDOWS_GENERATE_CRASHDUMP)

--- a/src/game/CServer.cpp
+++ b/src/game/CServer.cpp
@@ -2351,6 +2351,8 @@ bool CServer::CommandLinePostLoad( int argc, tchar * argv[] )
 #ifdef _WIN32
 			case 'C':
 			case 'K':
+		        //	these are parsed in other places - nt service, nt window part, etc
+		        continue;
             case 'J':
                 g_Serv._fCloseNTWindowOnTerminate = true;
                 continue;

--- a/src/game/CServer.cpp
+++ b/src/game/CServer.cpp
@@ -2350,8 +2350,6 @@ bool CServer::CommandLinePostLoad( int argc, tchar * argv[] )
 #ifdef _WIN32
 			case 'C':
 			case 'K':
-				//	these are parsed in other places - nt service, nt window part, etc
-				continue;
             case 'J':
                 g_Serv._fCloseNTWindowOnTerminate = true;
                 continue;
@@ -2360,6 +2358,9 @@ bool CServer::CommandLinePostLoad( int argc, tchar * argv[] )
 				g_UnixTerminal.setColorEnabled(false);
 				continue;
 #endif
+		    // Ini path definition, needs to be parsed before loading ini.
+		    case 'I':
+		        continue;
 			case 'P':
 				m_ip.SetPort((word)(atoi(pArg + 1)));
 				continue;

--- a/src/game/CServer.cpp
+++ b/src/game/CServer.cpp
@@ -2351,8 +2351,8 @@ bool CServer::CommandLinePostLoad( int argc, tchar * argv[] )
 #ifdef _WIN32
 			case 'C':
 			case 'K':
-		        //	these are parsed in other places - nt service, nt window part, etc
-		        continue;
+				//	these are parsed in other places - nt service, nt window part, etc
+				continue;
             case 'J':
                 g_Serv._fCloseNTWindowOnTerminate = true;
                 continue;

--- a/src/game/CServer.cpp
+++ b/src/game/CServer.cpp
@@ -2305,7 +2305,7 @@ bool CServer::CommandLinePreLoad( int argc, tchar * argv[] )
                     "-E Enable the CrashDumper.\n"
 #endif
                     "-Gpath/to/saves/ Defrags sphere saves.\n"
-					"-I /path/to/ini/ Directory with ini files.\n"
+					"-I=/path/to/ini/ Directory with ini files.\n"
 #ifdef _WIN32
                     "-K install/remove Installs or removes NT Service.\n"
                     "-J automatically close the console window at server termination.\n"

--- a/src/game/CServerConfig.cpp
+++ b/src/game/CServerConfig.cpp
@@ -4563,13 +4563,14 @@ bool CServerConfig::LoadIni( bool fTest )
 	ADDTOCALLSTACK("CServerConfig::LoadIni");
 
     char filename[SPHERE_MAX_PATH] = SPHERE_FILE ".ini";
-    // Check, if CLI argument -I /path/to/ini/directory/ was used.
+    // Check, if CLI argument -I=/path/to/ini/directory/ was used.
     if (m_iniDirectory[0] != '\0')
     {
-        int const ret = snprintf(filename, SPHERE_MAX_PATH, "%s/" SPHERE_FILE ".ini", m_iniDirectory);
+        int const ret = snprintf(filename, SPHERE_MAX_PATH, "%s" SPHERE_FILE ".ini", m_iniDirectory);
         if (ret < 0)
         {
-            abort();
+			g_Log.Event(LOGL_FATAL|LOGM_INIT|LOGF_CONSOLE_ONLY, "Path to %s" SPHERE_FILE ".ini is too long.\n", m_iniDirectory);
+            return false;
         }
     }
     else
@@ -4600,13 +4601,14 @@ bool CServerConfig::LoadCryptIni( void )
 	ADDTOCALLSTACK("CServerConfig::LoadCryptIni");
 
     char filename[SPHERE_MAX_PATH] = SPHERE_FILE "Crypt.ini";
-    // Check, if CLI argument -I /path/to/ini/directory/ was used.
+    // Check, if CLI argument -I=/path/to/ini/directory/ was used.
     if (m_iniDirectory[0] != '\0')
     {
-        int const ret = snprintf(filename, SPHERE_MAX_PATH, "%s/sphereCrypt.ini", m_iniDirectory);
+        int const ret = snprintf(filename, SPHERE_MAX_PATH, "%s" SPHERE_FILE "Crypt.ini", m_iniDirectory);
         if (ret < 0)
         {
-            abort();
+            g_Log.Event(LOGL_FATAL|LOGM_INIT|LOGF_CONSOLE_ONLY, "Path to %s" SPHERE_FILE "Crypt.ini is too long.\n", m_iniDirectory);
+            return false;
         }
     }
     else

--- a/src/game/CServerConfig.cpp
+++ b/src/game/CServerConfig.cpp
@@ -4625,11 +4625,12 @@ void CServerConfig::PrintEFOFFlags(bool bEF, bool bOF, CTextConsole *pSrc)
 #undef catresname
 }
 
-bool CServerConfig::LoadIni( bool fTest )
+bool CServerConfig::LoadIni(bool fTest)
 {
 	ADDTOCALLSTACK("CServerConfig::LoadIni");
 
     char filename[SPHERE_MAX_PATH] = SPHERE_FILE ".ini";
+
     // Check, if CLI argument -I=/path/to/ini/directory/ was used.
     if (m_iniDirectory[0] != '\0')
     {
@@ -4642,13 +4643,13 @@ bool CServerConfig::LoadIni( bool fTest )
     }
     else
     {
-        strncpy(filename, SPHERE_FILE ".ini", SPHERE_MAX_PATH);
+        Str_CopyLimitNull(filename, SPHERE_FILE ".ini", SPHERE_MAX_PATH);
     }
 
 	// Load my INI file first.
-	if ( ! OpenResourceFind( m_scpIni, filename, !fTest )) // Open script file
+	if (!OpenResourceFind(m_scpIni, filename, !fTest))
 	{
-		if( !fTest )
+		if (!fTest)
 		{
 			g_Log.Event(LOGL_FATAL|LOGM_INIT|LOGF_CONSOLE_ONLY, SPHERE_FILE ".ini has not been found.\n");
 			g_Log.Event(LOGL_FATAL|LOGM_INIT|LOGF_CONSOLE_ONLY, "Download a sample sphere.ini from https://github.com/Sphereserver/Source-X/tree/master/src\n");
@@ -4668,6 +4669,7 @@ bool CServerConfig::LoadCryptIni( void )
 	ADDTOCALLSTACK("CServerConfig::LoadCryptIni");
 
     char filename[SPHERE_MAX_PATH] = SPHERE_FILE "Crypt.ini";
+
     // Check, if CLI argument -I=/path/to/ini/directory/ was used.
     if (m_iniDirectory[0] != '\0')
     {
@@ -4680,12 +4682,12 @@ bool CServerConfig::LoadCryptIni( void )
     }
     else
     {
-        strncpy(filename, SPHERE_FILE "Crypt.ini", SPHERE_MAX_PATH);
+        Str_CopyLimitNull(filename, SPHERE_FILE "Crypt.ini", SPHERE_MAX_PATH);
     }
 
-    if ( ! OpenResourceFind( m_scpCryptIni, filename, false ) )
+    if (!OpenResourceFind(m_scpCryptIni, filename, false))
 	{
-		g_Log.Event( LOGL_WARN|LOGM_INIT, "Could not open " SPHERE_FILE "Crypt.ini, encryption might not be available\n");
+		g_Log.Event(LOGL_WARN|LOGM_INIT, "Could not open " SPHERE_FILE "Crypt.ini, encryption might not be available\n");
 		return false;
 	}
 
@@ -4693,8 +4695,8 @@ bool CServerConfig::LoadCryptIni( void )
 	m_scpCryptIni.Close();
 	m_scpCryptIni.CloseForce();
 
-	g_Log.Event( LOGM_INIT, "Loaded %" PRIuSIZE_T " client encryption keys.\n",
-		CCryptoKeysHolder::get()->client_keys.size() );
+	g_Log.Event(LOGM_INIT, "Loaded %" PRIuSIZE_T " client encryption keys.\n",
+		CCryptoKeysHolder::get()->client_keys.size());
 
 	return true;
 }

--- a/src/game/CServerConfig.cpp
+++ b/src/game/CServerConfig.cpp
@@ -4563,7 +4563,7 @@ bool CServerConfig::LoadIni( bool fTest )
 	ADDTOCALLSTACK("CServerConfig::LoadIni");
 
     char filename[SPHERE_MAX_PATH] = SPHERE_FILE ".ini";
-    // Check, if CLI argument -S /path/to/ini/directory/ was used.
+    // Check, if CLI argument -I /path/to/ini/directory/ was used.
     if (m_iniDirectory[0] != '\0')
     {
         int const ret = snprintf(filename, SPHERE_MAX_PATH, "%s/" SPHERE_FILE ".ini", m_iniDirectory);

--- a/src/game/CServerConfig.h
+++ b/src/game/CServerConfig.h
@@ -650,9 +650,11 @@ public:
 
 private:
 	CResourceID ResourceGetNewID( RES_TYPE restype, lpctstr pszName, CVarDefContNum ** ppVarNum, bool fNewStyleDef );
+    char m_iniDirectory[SPHERE_MAX_PATH];
 
 public:
 	CServerConfig();
+    void SetIniDirectory(const char* path);
 	virtual ~CServerConfig();
 
 	CServerConfig(const CServerConfig& copy) = delete;

--- a/src/game/spheresvr.cpp
+++ b/src/game/spheresvr.cpp
@@ -507,6 +507,26 @@ int main( int argc, char * argv[] )
 
     // We need to find out the log files folder... look it up in the .ini file (on Windows it's done in WinMain function).
     g_Serv.SetServerMode(SERVMODE_PreLoadingINI);
+
+    // Parse command line arguments.
+    for (int argn = 1; argn < argc; ++argn)
+    {
+        const tchar * cliArg = argv[argn];
+        if (! _IS_SWITCH(cliArg[0]))
+        {
+            continue;
+        }
+
+        ++cliArg;
+
+        // Check if we are changing ini path.
+        if (toupper(cliArg[0]) == 'I')
+        {
+            // Define path to ini files.
+            g_Cfg.SetIniDirectory(cliArg + 2);
+        }
+    }
+
     g_Cfg.LoadIni(false);
 #endif
 

--- a/src/sphere.ini
+++ b/src/sphere.ini
@@ -37,7 +37,7 @@ Lang=English
 
 // Starts Sphere as a system service on Windows XP and newer.
 // To install Sphere as service, set this to 1 and run sphere from cli with `-k install` parameter.
-// To uninstall service, use `-k uninstall` parameter.
+// To uninstall service, use `-k remove` parameter.
 NTService=0
 
 // MariaDB (MySQL) configuration

--- a/src/sphere/ntservice.cpp
+++ b/src/sphere/ntservice.cpp
@@ -461,7 +461,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 
 	TCHAR	*argv[32];
 	argv[0] = nullptr;
-	int argc = Str_ParseCmds(lpCmdLine, &argv[1], ARRAY_COUNT(argv)-1, " \t") + 1;
+	int argc = Str_ParseCmds(lpCmdLine, &argv[1], ARRAY_COUNT(argv)-1, " =\t") + 1;
 
     // Process the command line arguments.
     if (argc > 1 && _IS_SWITCH(*argv[1]))

--- a/src/sphere/ntservice.cpp
+++ b/src/sphere/ntservice.cpp
@@ -463,6 +463,20 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 	argv[0] = nullptr;
 	int argc = Str_ParseCmds(lpCmdLine, &argv[1], ARRAY_COUNT(argv)-1, " \t") + 1;
 
+    // Process the command line arguments.
+    if (argc > 1 && _IS_SWITCH(*argv[1]))
+    {
+        // Check if we are changing ini path.
+        if (toupper(argv[1][1]) == 'I')
+        {
+            if (argc == 3)
+            {
+                // Define path to ini files.
+                g_Cfg.SetIniDirectory(argv[2]);
+            }
+        }
+    }
+
 	// We need to find out what the server name is and the log files folder... look it up in the .ini file
     if (!g_Cfg.LoadIni(false))
     {

--- a/src/sphere/ntservice.cpp
+++ b/src/sphere/ntservice.cpp
@@ -473,7 +473,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
             {
                 // Clean quotes around path, if it contains spaces.
                 const char* raw = argv[2];
-                char path[MAX_PATH];
+                char path[SPHERE_MAX_PATH];
                 size_t j = 0;
                 for (size_t i = 0; raw[i] != '\0' && j < sizeof(path) - 1; ++i) {
                     if (raw[i] != '"') {

--- a/src/sphere/ntservice.cpp
+++ b/src/sphere/ntservice.cpp
@@ -449,6 +449,8 @@ void CNTService::CmdMainStart()
 //
 //	FUNCTION: main()
 //
+// @todo Refactor installing and starting service after https://github.com/Sphereserver/Source-X/issues/1400 is resolved.
+//
 /////////////////////////////////////////////////////////////////////////////////////
 #ifdef MSVC_COMPILER
 int WINAPI WinMain(_In_ HINSTANCE hInstance, _In_opt_ HINSTANCE hPrevInstance, _In_ LPSTR lpCmdLine, _In_ int nCmdShow)

--- a/src/sphere/ntservice.cpp
+++ b/src/sphere/ntservice.cpp
@@ -466,13 +466,24 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     // Process the command line arguments.
     if (argc > 1 && _IS_SWITCH(*argv[1]))
     {
-        // Check if we are changing ini path.
+        // Check if we are changing the ini path.
         if (toupper(argv[1][1]) == 'I')
         {
             if (argc == 3)
             {
-                // Define path to ini files.
-                g_Cfg.SetIniDirectory(argv[2]);
+                // Clean quotes around path, if it contains spaces.
+                const char* raw = argv[2];
+                char path[MAX_PATH];
+                size_t j = 0;
+                for (size_t i = 0; raw[i] != '\0' && j < sizeof(path) - 1; ++i) {
+                    if (raw[i] != '"') {
+                        path[j++] = raw[i];
+                    }
+                }
+                path[j] = '\0';
+
+                // Define path to the ini files.
+                g_Cfg.SetIniDirectory(path);
             }
         }
     }


### PR DESCRIPTION
Not sure, if everything is done correctly, but it allows usage with cli argument `-I=/path/` to define path to folder with ini files.

See changelog entry for usage and caveeats.