### PR TITLE
Fix for container spam / crash

### DIFF
--- a/src/game/items/CItemContainer.cpp
+++ b/src/game/items/CItemContainer.cpp
@@ -513,7 +513,6 @@ CPointMap CItemContainer::GetRandContainerLoc() const
 		    minValY = sm_ContSize[i].m_miny;
 		    maxValX = sm_ContSize[i].m_maxx;
 		    maxValY = sm_ContSize[i].m_maxy;
-			g_Log.EventWarn("Relying on default container sizes is discouraged. Define TDATA3/4 on container 0%x.\n", GetDispID());
 
 			break;
 		}

--- a/src/game/items/CItemContainer.cpp
+++ b/src/game/items/CItemContainer.cpp
@@ -462,14 +462,13 @@ CPointMap CItemContainer::GetRandContainerLoc() const
 	};
 
 	// Get a random location in the container.
-
 	const CItemBase *pItemDef = Item_GetDef();
     const GUMP_TYPE gump = pItemDef->m_ttContainer.m_idGump;	// Get the TDATA2
 
     const int iRandOnce = g_Rand.GetValFast(UINT16_MAX);
 
-	// check for custom values in TDATA3/TDATA4
-	if ( pItemDef->m_ttContainer.m_dwMinXY || pItemDef->m_ttContainer.m_dwMaxXY )
+	// Check for custom values in TDATA3/TDATA4.
+	if ( pItemDef->m_ttContainer.m_dwMinXY && pItemDef->m_ttContainer.m_dwMaxXY )
 	{
         const int tmp_MinX = pItemDef->m_ttContainer.m_dwMinXY >> 16;
         const int tmp_MinY = (pItemDef->m_ttContainer.m_dwMinXY & 0x0000FFFF);
@@ -557,7 +556,7 @@ void CItemContainer::ContentAdd( CItem *pItem, CPointMap pt, bool bForceNoStack,
     short maxValX = 512;
     short maxValY = 512;
 
-	if (pContDef->m_ttContainer.m_dwMinXY || pContDef->m_ttContainer.m_dwMaxXY)
+	if (pContDef->m_ttContainer.m_dwMinXY && pContDef->m_ttContainer.m_dwMaxXY)
 	{
 		const short tmp_MinX = (short)( pContDef->m_ttContainer.m_dwMinXY >> 16 );
         const short tmp_MinY = (short)( (pContDef->m_ttContainer.m_dwMinXY & 0x0000FFFF) );

--- a/src/game/items/CItemContainer.cpp
+++ b/src/game/items/CItemContainer.cpp
@@ -481,6 +481,12 @@ CPointMap CItemContainer::GetRandContainerLoc() const
         maxValX = pItemDef->m_ttContainer.m_dwMaxXY >> 16;
         maxValY = (pItemDef->m_ttContainer.m_dwMaxXY & 0x0000FFFF);
 
+	    // Make sure this value aren't same, we can't divide by zero.
+	    if (maxValX == minValX)
+	        maxValX += 1;
+	    if (maxValY == minValY)
+	        maxValY += 1;
+
 	    return {
 	        static_cast<short>(minValX + (iRandOnce % (maxValX - minValX))),
             static_cast<short>(minValY + (iRandOnce % (maxValY - minValY))),

--- a/src/game/items/CItemContainer.h
+++ b/src/game/items/CItemContainer.h
@@ -73,7 +73,10 @@ public:
 
 	virtual void DupeCopy( const CObjBase * pItem ) override;  // overriding CItem::DupeCopy
 
-	CPointMap GetRandContainerLoc() const;
+    /**
+     * Gets the random location in container based on sizes defined in tdata3/4.
+     */
+    CPointMap GetRandContainerLoc() const;
 
 	void OnOpenEvent( CChar * pCharOpener, const CObjBaseTemplate * pObjTop );
 };


### PR DESCRIPTION
Using tdata3/4 requires both values. Add default value for random value if container gump is undefined. Warn about undefined container sizes.