### PR TITLE
Show real character name on login screen

### DIFF
--- a/src/game/clients/CClientMsg.cpp
+++ b/src/game/clients/CClientMsg.cpp
@@ -1594,7 +1594,7 @@ uint CClient::Setup_FillCharList(Packet* pPacket, const CChar * pCharFirst)
 	{
 		m_tmSetupCharList[0] = pCharFirst->GetUID();
 
-		pPacket->writeStringFixedASCII(pCharFirst->GetName(), MAX_NAME_SIZE);
+		pPacket->writeStringFixedASCII(pCharFirst->GetNameWithoutIncognito(), MAX_NAME_SIZE);
 		pPacket->writeStringFixedASCII("", MAX_NAME_SIZE);
 
 		++count;
@@ -1620,7 +1620,7 @@ uint CClient::Setup_FillCharList(Packet* pPacket, const CChar * pCharFirst)
 
 		m_tmSetupCharList[count] = uid;
 
-		pPacket->writeStringFixedASCII(pChar->GetName(), MAX_NAME_SIZE);
+		pPacket->writeStringFixedASCII(pChar->GetNameWithoutIncognito(), MAX_NAME_SIZE);
 		pPacket->writeStringFixedASCII("", MAX_NAME_SIZE);
 
 		++count;


### PR DESCRIPTION
When character has incognito flag, his real name isn't show on login screen. This causes player to loose his desktop, when logging.

This change was discussed on Classic UO Discord and is beeing implemented on ServUO/TrueUO, see links:

https://github.com/ServUO/ServUO/pull/5113
https://github.com/TrueUO/TrueUO/pull/1471

PR on Classic UO, which would be clientside workaround.
https://github.com/ClassicUO/ClassicUO/pull/1807

I have no idea, how this works on EA, but this is pretty much QoL and EA shouldn't be reflected here.