### PR TITLE
Fix hex parsing

### DIFF
--- a/src/common/CExpression.cpp
+++ b/src/common/CExpression.cpp
@@ -673,7 +673,8 @@ llong CExpression::GetSingle(lpctstr & refStrExpr )
 			if ( IsDigit(ch) )
             {
 				ch -= '0';
-                ++ uiDigits;
+			    // The line bellow causes flags over 080000000 not being read correctly. But this whole section should be refactored...
+                //++ uiDigits;
             }
             else
 			{


### PR DESCRIPTION
flags over 080000000 giving false values (introduced in 0467bfcae9dbccd9ba31c2182b1acc124783a722 and 17a1cb2d7d2b3b41cdf9f9675cf2384ec498af50

Fixes #1448 