### PR TITLE
ARGN3 for @PersonalSpace trigger to bypass max stamina requirement (#1250 #1455)

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4050,3 +4050,6 @@ When setting a property like MORE to the a spell or skill defname, trying to rea
 
 16-05-2025, Mulambo
 - Changed: When equipping item by dragging or using Dress macro, the item layer is now showing actual layer of the object in EquipTest and ItemEquipTest trigger (instead of 31 = LAYER_DRAGGING). This is the same behaviour, as equipping by double clicking.
+
+24-09-2025, Mulambo
+- Added: ARGN3 for trigger @PersonalSpace [R/W], allowing to bypass maximum stamina requirement (default 1 = require maximum stamina).


### PR DESCRIPTION
Entry for wiki needed: https://wiki.spherecommunity.net/index.php?title=@PersonalSpace


<table border="1" cellspacing="4" cellpadding="4">
<tr>
<td> <b>Argument</b> </td>
<td> <b>In/Out</b> </td>
<td> <b>Description</b>
</td></tr>
<tr>
<td> ARGN1 </td>
<td> IO </td>
<td> The amount of stamina needed to step on to the character.
</td></tr>
<tr>
<td> ARGN2 </td>
<td> O  </td>
<td> Setting it to 1 allow NPCs to pass over another NPCs, 0 reject the movement.
</td></tr>
<tr>
<td> ARGN3 </td>
<td> IO  </td>
<td> Setting it to 0 will allow stepping over characters without maximum stamina. Default = 1.
</td></tr>
</table>