### PR TITLE
Notoriety

### DIFF
--- a/src/game/chars/CChar.h
+++ b/src/game/chars/CChar.h
@@ -696,16 +696,16 @@ public:
 	NOTO_TYPE Noto_GetFlag( const CChar * pChar, bool fIncog = true, bool fInvul = false, bool fGetColor = false ) const;
 
 	/**
-	* @brief Notoriety calculations
+	* Notoriety calculations. What is this char to the viewer? This allows the noto attack check in the client.
 	*
 	* TAG.OVERRIDE.NOTO will override everything and use the value in the tag for everyone, regardless of what I really are for them.
 	* If this char is a pet, check if notoriety must be inherited from its master or do regular checks for it.
-	* @param pChar is the CChar that needs to know what I am (good, evil, criminal, neutral...) to him.
-	* @param fIncog if set to true (usually because of Incognito spell), this character will be gray for the viewer (pChar).
-	* @param fInvul if set to true invulnerable characters will return NOTO_INVUL (yellow bar, etc).
+	* @param pCharViewer is the CChar that needs to know what I am (good, evil, criminal, neutral...) to him.
+	* @param fAllowIncog if set to true (usually because of Incognito spell), this character will be gray for the viewer (pChar).
+	* @param fAllowInvul if set to true invulnerable characters will return NOTO_INVUL (yellow bar, etc).
 	* @return NOTO_TYPE notoriety level.
 	*/
-	NOTO_TYPE Noto_CalcFlag( const CChar * pChar, bool fIncog = false, bool fInvul = false ) const;
+	NOTO_TYPE Noto_CalcFlag( const CChar * pCharViewer, bool fAllowIncog = false, bool fAllowInvul = false ) const;
 
 	/**
 	* @brief What color should the viewer see from me?
@@ -860,6 +860,25 @@ public:
 	*/
 	void NotoSave_CheckTimeout();
 
+    /**
+     * Helper for checking guild / town war status.
+     */
+    enum NOTO_WAR_STATUS: byte
+    {
+        NOTO_WAR_NONE = 0,
+        NOTO_WAR_ALLY,
+        NOTO_WAR_ENEMY,
+    };
+
+    /**
+     * Checks ally / war status between two guild / town stones.
+     *
+     * @param pMyStone My Guild/Town stone.
+     * @param pViewerStone The character's looking at me Guild/Town stone.
+     * @return War status (none, ally, enemy)
+     */
+    NOTO_WAR_STATUS Noto_GetWarStatus(const CItemStone* pMyStone, const CItemStone* pViewerStone) const;
+
 	/**
 	* @brief We are snooping or stealing, is taking this item a crime ?
 	*
@@ -868,7 +887,6 @@ public:
 	* @return false = no crime.
 	*/
 	bool IsTakeCrime( const CItem * pItem, CChar ** ppCharMark = nullptr ) const;
-
 
 	/**
 	* @brief We killed a character, starting exp calcs

--- a/src/sphere.ini
+++ b/src/sphere.ini
@@ -873,7 +873,7 @@ Experimental=0
 // OF_OWNoDropCarriedItem		00400000 // When overweighted, don't drop items on ground when moving them (or using BOUNCE) and checking if you can carry them.
 // OF_AllowContainerInsideContainer	00800000 // Allow containers inside other containers even if they are heavier than the container being inserted into.
 // OF_VendorStockLimit			01000000 // Limits how much of an item a vendor can buy using the value set in the TEMPLATE. Format: BUY=ID,AMOUNT
-// OF_EnableGuildAlignNotoriety		02000000 // If enabled, guilds with the same alignment will see each other as enemy or ally.
+// OF_EnableGuildAlignNotoriety		02000000 // If enabled, guilds with the same alignment (order / chaos) will see each other as allies (green).
 // OF_NoDclickEquip			04000000 // If enabled, double-click does not equip items.
 // OF_PetBehaviorOwnerNeutral		08000000 // Should my pets always appear natural to me?
 // OF_NPCMovementOldStyle           010000000 // Required setting to make NPCs run like in the old Sphere versions (0.56b).


### PR DESCRIPTION
Refactored Noto_GetFlag
- fixed issue with neutral guilds looking like enemies (#1094)
- oposite faction is always enemy
-  OF_EnableGuildAlignNotoriety works only for allies in the same fraction