### PR TITLE
Fix of pets not continue fight after casting spell (All kill commands)

### DIFF
--- a/src/game/chars/CCharNPCPet.cpp
+++ b/src/game/chars/CCharNPCPet.cpp
@@ -445,6 +445,7 @@ bool CChar::NPC_OnHearPetCmdTarg( int iCmd, CChar *pSrc, CObjBase *pObj, const C
 			if ( !pCharTarg || pCharTarg == pSrc || pCharTarg == this )
 				break;
             fSuccess = pCharTarg->OnAttackedBy(pSrc, true);	// we know who told them to do this.
+            pSrc->OnHarmedBy(pCharTarg);
             if ( fSuccess )
                 fSuccess = Fight_Attack(pCharTarg, true);
 			break;


### PR DESCRIPTION
So there has been long time issue of pets that suppose to be casters, not continue fighting after spell gets off. They would immediately follow master.
Turns out whenever the master doesnt have memory OnHarmedBy(Enemy), pets will just not stick to the target.

If player wanted his pets/summons to stick fighting and casting, he would have to call all guard me and attack target.