### PR TITLE
Fix - players equipping gear by drag in to paperdoll

### DIFF
--- a/src/game/chars/CCharStatus.cpp
+++ b/src/game/chars/CCharStatus.cpp
@@ -920,6 +920,9 @@ CChar * CChar::GetOwner() const
 
 bool CChar::CanDress(const CChar* pChar) const
 {
+    // Self dressing always allowed
+    if (pChar == this)
+        return true;
     if (IsPriv(PRIV_GM) && (GetPrivLevel() > pChar->GetPrivLevel() || GetPrivLevel() == PLEVEL_Owner))
         return true;
     else if (g_Cfg.m_fCanUndressPets && pChar->IsOwnedBy(this))


### PR DESCRIPTION
Players cannot equip gear on themselves by drag on the paperdoll
It was blocked by fixing this issue https://github.com/Sphereserver/Source-X/issues/901