### PR TITLE
Fix casting abort

### DIFF
--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -1365,7 +1365,7 @@ bool CChar::Fight_Clear(CChar *pChar, bool fForced)
     if ( !pChar || !Attacker_Delete(pChar, fForced, ATTACKER_CLEAR_FORCED) )
 		return false;
 
-    if (Skill_GetActive() != SKILL_MAGERY)
+    if (!g_Cfg.IsSkillFlag(Skill_GetActive(), SKF_MAGIC))
     {
         m_atFight.m_iWarSwingState = WAR_SWING_EQUIPPING;
     }

--- a/src/game/chars/CCharFight.cpp
+++ b/src/game/chars/CCharFight.cpp
@@ -1365,7 +1365,10 @@ bool CChar::Fight_Clear(CChar *pChar, bool fForced)
     if ( !pChar || !Attacker_Delete(pChar, fForced, ATTACKER_CLEAR_FORCED) )
 		return false;
 
-    m_atFight.m_iWarSwingState = WAR_SWING_EQUIPPING;
+    if (Skill_GetActive() != SKILL_MAGERY)
+    {
+        m_atFight.m_iWarSwingState = WAR_SWING_EQUIPPING;
+    }
     m_atFight.m_iRecoilDelay = 0;
     m_atFight.m_iSwingAnimationDelay = 0;
     m_atFight.m_iSwingAnimation = 0;


### PR DESCRIPTION
Casting was aborted if other monster with attacker (me) died. Because Attacker_Clear nulls the ACTARG1 (which is spell def during cast). #1539