### PR TITLE
fix: npc and summons not casting

### DIFF
--- a/src/game/chars/CCharNPC.cpp
+++ b/src/game/chars/CCharNPC.cpp
@@ -340,4 +340,6 @@ void CChar::NPC_CreateTrigger()
 		if (iRet != TRIGRET_RET_FALSE && iRet != TRIGRET_RET_DEFAULT)
 			return;
 	}
+	if (m_pNPC)
+		NPC_GetAllSpellbookSpells();
 }


### PR DESCRIPTION
The only time NPC spell loading from the spellbook is triggered is during script/worldsave loading, which is why summons and NPC's don’t cast spells.
With this change, spells are also loaded when the ON=@Create trigger is called → TEVENTS → PETEVENTS (@Create on the LINK ref), and then it attempts to load the spellbook.