### PR TITLE
Combat Chance to Hit changes

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4094,3 +4094,10 @@ When setting a property like MORE to the a spell or skill defname, trying to rea
 4-12-2025, Nolok
 - Fixed: Malformed spell flags being returned via scripts.
 - Fixed: REGION ISEVENT didn't (always?) find REGIONTYPES.
+
+23-02-2026, Mulambo
+- Modified CombatHitChanceEra:
+  - Fixed: IncreaseDefChance on AOS formula (2) is now properly calculated from defender, rather than attacker.
+  - Fixed: Hit chance to paralyzed targets with sphere custom (0) formula is now 80-100% (was 0-10%).
+  - Changed: Hit chance output from sphere custom formula (0) is now properly calculated value (ie. if your chance to hit was 80%, output value was calculated as random number from 80, its 80 now).
+  - Added: Implemented Hit chance increase / decrease to sphere custom formula (0).

--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4111,10 +4111,11 @@ When setting a property like MORE to the a spell or skill defname, trying to rea
 11-03-2026, Mulambo
 - Added: New experimental flag EF_WalkBypassMonsters. This will override hardcoded client behaviour that prevents stepping over NPCs without max stamina (like GM can). However, this could cause flickering or lags to clients and should be used with caution.
 
+16-03-2026, Mulambo
+- Fixed: Issue with loosing target when somebody dies in combat (#1559)
 
 17-03-2026, Mulambo
 - Modified CombatHitChanceEra:
-  - Fixed: IncreaseDefChance on AOS formula (2) is now properly calculated from defender, rather than attacker.
+  - Fixed: IncreaseDefChance on AOS formula (2) is now properly calculated from defender, not the attacker.
   - Fixed: Hit chance to paralyzed targets with sphere custom (0) formula is now 80-100% (was 0-10%).
-  - Changed: Hit chance output from sphere custom formula (0) is now properly calculated value (ie. if your chance to hit was 80%, output value was calculated as random number from 80, its 80 now).
   - Added: Implemented Hit chance increase / decrease to sphere custom formula (0).

--- a/src/game/CResourceCalc.cpp
+++ b/src/game/CResourceCalc.cpp
@@ -176,6 +176,10 @@ int CServerConfig::Calc_CombatChanceToHit(const CChar * pChar, const CChar * pCh
 			int iChance = (iSkillAttack - iSkillDefend) / 5;
 			iChance = (iSkillVal - iChance) / 10;
 
+		    // Modify chance with IncreaseHit and IncreaseDef properties.
+		    iChance += static_cast<int>(pChar->GetPropNum(COMP_PROPS_CHAR, PROPCH_INCREASEHITCHANCE, true));
+		    iChance -= static_cast<int>(pCharTarg->GetPropNum(COMP_PROPS_CHAR, PROPCH_INCREASEDEFCHANCE, true));
+
 		    // Impossible to hit.
 			if (iChance < 0)
 				iChance = 0;

--- a/src/game/CResourceCalc.cpp
+++ b/src/game/CResourceCalc.cpp
@@ -154,10 +154,6 @@ int CServerConfig::Calc_CombatChanceToHit(const CChar * pChar, const CChar * pCh
 		default:
 		case 0:
 		{
-		    // Paralyzed or sleeping target. It should be easy.
-			if (pCharTarg->IsStatFlag(STATF_SLEEPING | STATF_FREEZE))
-				return(g_Rand.GetVal(10));
-
 		    // Get a value of weapon skill attacker is using.
 			const int iSkillVal = pChar->Skill_GetAdjusted(skillAttacker);
 
@@ -177,18 +173,21 @@ int CServerConfig::Calc_CombatChanceToHit(const CChar * pChar, const CChar * pCh
 			else
 				iSkillDefend = (iSkillDefend + iStam * 10) / 2;
 
-			int iDiff = (iSkillAttack - iSkillDefend) / 5;
-			iDiff = (iSkillVal - iDiff) / 10;
+			int iChance = (iSkillAttack - iSkillDefend) / 5;
+			iChance = (iSkillVal - iChance) / 10;
 
 		    // Impossible to hit.
-			if (iDiff < 0)
-				iDiff = 0;
+			if (iChance < 0)
+				iChance = 0;
 		    // Always hit.
-			else if (iDiff > 100)
-				iDiff = 100;
+			else if (iChance > 100)
+				iChance = 100;
 
-		    // Always need to have some chance.
-			return g_Rand.GetVal(iDiff);
+		    // Paralyzed or sleeping target. It should be easy.
+		    if (pCharTarg->IsStatFlag(STATF_SLEEPING | STATF_FREEZE) && iChance < 80)
+		        iChance = 80;
+
+			return iChance;
 		}
 		// Pre-AOS formula.
 		case 1:
@@ -218,7 +217,7 @@ int CServerConfig::Calc_CombatChanceToHit(const CChar * pChar, const CChar * pCh
 			}
 			iAttackerSkill = ((iAttackerSkill / 10) + 20) * (100 + std::min(iAttackerHitChance, 45));
 
-			const int iTargetIncreaseDefChance = (int)(pChar->GetPropNum(COMP_PROPS_CHAR, PROPCH_INCREASEDEFCHANCE, true));
+			const int iTargetIncreaseDefChance = (int)(pCharTarg->GetPropNum(COMP_PROPS_CHAR, PROPCH_INCREASEDEFCHANCE, true));
 			const int iTargetSkill = ((pCharTarg->Skill_GetBase(skillTarget) / 10) + 20) * (100 + std::min(iTargetIncreaseDefChance, 45));
 
 			int iChance = iAttackerSkill * 100 / (iTargetSkill * 2);

--- a/src/game/CResourceCalc.cpp
+++ b/src/game/CResourceCalc.cpp
@@ -193,7 +193,8 @@ int CServerConfig::Calc_CombatChanceToHit(const CChar * pChar, const CChar * pCh
 		    if (pCharTarg->IsStatFlag(STATF_SLEEPING | STATF_FREEZE) && iChance < 80)
 		        iChance = 80;
 
-			return g_Rand.GetVal(iChance);	// always need to have some chance. );
+		    // Always need to have some chance (@todo Remove this horrendous random).
+			return g_Rand.GetVal(iChance);
 		}
 		// Pre-AOS formula.
 		case 1:

--- a/src/game/CResourceCalc.cpp
+++ b/src/game/CResourceCalc.cpp
@@ -193,7 +193,7 @@ int CServerConfig::Calc_CombatChanceToHit(const CChar * pChar, const CChar * pCh
 		    if (pCharTarg->IsStatFlag(STATF_SLEEPING | STATF_FREEZE) && iChance < 80)
 		        iChance = 80;
 
-			return iChance;
+			return g_Rand.GetVal(iChance);	// always need to have some chance. );
 		}
 		// Pre-AOS formula.
 		case 1:

--- a/src/game/CResourceCalc.cpp
+++ b/src/game/CResourceCalc.cpp
@@ -177,8 +177,10 @@ int CServerConfig::Calc_CombatChanceToHit(const CChar * pChar, const CChar * pCh
 			iChance = (iSkillVal - iChance) / 10;
 
 		    // Modify chance with IncreaseHit and IncreaseDef properties.
-		    iChance += static_cast<int>(pChar->GetPropNum(COMP_PROPS_CHAR, PROPCH_INCREASEHITCHANCE, true));
-		    iChance -= static_cast<int>(pCharTarg->GetPropNum(COMP_PROPS_CHAR, PROPCH_INCREASEDEFCHANCE, true));
+		    const int hitChangeIncrease = static_cast<int>(pChar->GetPropNum(COMP_PROPS_CHAR, PROPCH_INCREASEHITCHANCE, true));
+		    const int hitChanceDecrease = static_cast<int>(pCharTarg->GetPropNum(COMP_PROPS_CHAR, PROPCH_INCREASEDEFCHANCE, true));
+		    iChance = iChance * (100 + hitChangeIncrease) / 100;
+		    iChance = iChance * (100 - hitChanceDecrease) / 100;
 
 		    // Impossible to hit.
 			if (iChance < 0)

--- a/src/game/CServerConfig.h
+++ b/src/game/CServerConfig.h
@@ -1009,16 +1009,17 @@ public:
      * @return  The calculated combat attack speed.
      */
 	int Calc_CombatAttackSpeed( const CChar * pChar, const CItem * pWeapon ) const;
+    int Calc_CombatChanceToHit(const CChar *pChar, const CChar *pCharTarg) const;
 
     /**
-     * @brief   Calculates the combat chance to hit.
+     * Compares attacker skill vs defender skill to calculate the hit chance in combat.
      *
-     * @param [in,out]  pChar       If non-null, the character.
-     * @param [in,out]  pCharTarg   If non-null, the character targ.
+     * @param pChar Attacking character.
+     * @param pCharTarg Defending character.
      *
-     * @return  The calculated combat chance to hit.
+     * @return The calculated chance to hit in combat (0-100%).
      */
-	int Calc_CombatChanceToHit( CChar * pChar, CChar * pCharTarg);
+	int Calc_CombatChanceToHit(const CChar * pChar, const CChar * pCharTarg);
 
     /**
      * @brief   Calculates the combat chance to parry.

--- a/src/sphere.ini
+++ b/src/sphere.ini
@@ -436,7 +436,7 @@ CombatArcheryMovementDelay=10
 CombatDamageEra=0
 
 // Hit Chance formula to use on physical combat
-// 0 = Sphere custom	// Not compatible with Hit Chance Increase property
+// 0 = Sphere custom
 // 1 = pre-AOS			// Not compatible with Hit Chance Increase property
 // 2 = AOS
 CombatHitChanceEra=0


### PR DESCRIPTION
**AOS formula:** 
- fix: loading PROPCH_INCREASEDEFCHANCE for defender

**Sphere custom formula:**
- fix: hit chance to paralyzed targets (was 0-10%, is 80-100%)
- feat: implement IncreaseHitChance and IncreaseDefChance

+ minor refactoring