### PR TITLE
Fix the error message when try login with a linger char.

### DIFF
--- a/src/game/clients/CClientLog.cpp
+++ b/src/game/clients/CClientLog.cpp
@@ -140,8 +140,11 @@ bool CClient::addLoginErr(byte code)
 			code = PacketLoginError::Invalid;
 			break;
 		case PacketLoginError::InUse:
-		case PacketLoginError::CharIdle:
+		case PacketLoginError::BadCharacter:
 			code = PacketLoginError::InUse;
+			break;
+		case PacketLoginError::CharIdle:
+			code = static_cast<PacketLoginError::Reason>(PacketWarningMessage::CharacterInWorld);
 			break;
 		case PacketLoginError::Blocked:
 		case PacketLoginError::BlockedIP:
@@ -156,7 +159,6 @@ bool CClient::addLoginErr(byte code)
 			break;
 		case PacketLoginError::Other:
 		case PacketLoginError::BadVersion:
-		case PacketLoginError::BadCharacter:
 		case PacketLoginError::BadAuthID:
 		case PacketLoginError::BadEncLength:
 		case PacketLoginError::EncCrypt:


### PR DESCRIPTION


I used a static_cast because I thought simply enter a 5 was not good. We already beter define  this value on the PacketWarningMessage method