### PR TITLE
add NAME.PREFIX and NAME.SUFFIX support to addItemName

### DIFF
--- a/Changelog.txt
+++ b/Changelog.txt
@@ -4141,3 +4141,6 @@ When setting a property like MORE to the a spell or skill defname, trying to rea
 19-05-2026, nightNR
 - Fixed: pre-AOS armor rating (AR) calculation (#1550).
 - Fixed NPCs can't cast spells from spellbook after respawn (#1551).
+
+29-05-2026, canerksk
+- Added: NAME.PREFIX and NAME.SUFFIX support for items in addItemName, matching existing addCharName behaviour.

--- a/src/game/clients/CClientMsg.cpp
+++ b/src/game/clients/CClientMsg.cpp
@@ -1223,7 +1223,13 @@ void CClient::addItemName( CItem * pItem )
 	lpctstr pszNameFull = pItem->GetNameFull( fIdentified );
 
 	tchar szName[ MAX_ITEM_NAME_SIZE * 2 ];
-	size_t len = Str_CopyLimitNull( szName, pszNameFull, ARRAY_COUNT(szName) );
+
+    Str_CopyLimitNull(szName, pItem->GetKeyStr("NAME.PREFIX"), ARRAY_COUNT(szName));
+    Str_ConcatLimitNull(szName, pszNameFull, ARRAY_COUNT(szName));
+    Str_ConcatLimitNull(szName, pItem->GetKeyStr("NAME.SUFFIX"), ARRAY_COUNT(szName));
+
+	//size_t len = Str_CopyLimitNull( szName, pszNameFull, ARRAY_COUNT(szName) );
+    size_t len = strlen(szName);
 
 	const CContainer* pCont = dynamic_cast<const CContainer*>(pItem);
 	if ( pCont != nullptr )


### PR DESCRIPTION
Apply NAME.PREFIX and NAME.SUFFIX key lookups in addItemName, matching the existing behaviour in addCharName. Previously, setting these keys on an item had no effect on the singleclick label. Also removes the duplicate Str_CopyLimitNull call that was overwriting the assembled string.